### PR TITLE
add a test/example to setup sha256 circuit

### DIFF
--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 # ARK Libraries
 ark-std = {version = "0.4.0", default-features = false, features = [ "print-trace", "std" ]}
+ark-crypto-primitives = {version = "0.4.0", default-features = false}
 ark-ff = {version = "0.4.0", default-features = false}
 ark-poly = {version = "0.4.0", default-features = false}
 ark-ec = {version = "0.4.0", default-features = false}

--- a/groth16/src/qap.rs
+++ b/groth16/src/qap.rs
@@ -92,7 +92,9 @@ pub fn qap<F: PrimeField, D: EvaluationDomain<F>>(
 mod tests {
     use super::*;
     use ark_bn254::{Bn254, Fr};
-    use ark_circom::{CircomBuilder, CircomConfig};
+    use ark_circom::{CircomBuilder, CircomConfig, CircomReduction};
+    use ark_crypto_primitives::snark::SNARK;
+    use ark_groth16::Groth16;
     use ark_poly::Radix2EvaluationDomain;
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
 
@@ -117,5 +119,24 @@ mod tests {
         let qap =
             qap::<Fr, Radix2EvaluationDomain<_>>(&matrices, &full_assignment);
         eprintln!("{:?}", qap);
+    }
+
+    #[test]
+    fn setup() {
+        let cfg = CircomConfig::<Bn254>::new(
+            "../fixtures/sha256/sha256.wasm",
+            "../fixtures/sha256/sha256.r1cs",
+        )
+        .unwrap();
+        let builder = CircomBuilder::new(cfg);
+        let circom = builder.setup();
+        let rng = &mut ark_std::rand::thread_rng();
+        let (pk, vk) =
+            Groth16::<Bn254, CircomReduction>::circuit_specific_setup(
+                circom, rng,
+            )
+            .unwrap();
+
+        // Do something with keys.
     }
 }

--- a/groth16/src/qap.rs
+++ b/groth16/src/qap.rs
@@ -124,7 +124,7 @@ mod tests {
     #[test]
     fn setup() {
         let cfg = CircomConfig::<Bn254>::new(
-            "../fixtures/sha256/sha256.wasm",
+            "../fixtures/sha256/sha256_js/sha256.wasm",
             "../fixtures/sha256/sha256.r1cs",
         )
         .unwrap();


### PR DESCRIPTION
I did realize for our simple testing circuit `sha256` there is no need to upload the proving key (`pk`) in the fixtures, we can generate it on the fly. On my M1 Machine, in debug mode it generates the pk around 6s and in release mode it takes less than half a second (320ms, to be specific.)

<details>
  <summary>Debug mode statics</summary>

```rust
Start:   Groth16::Generator
··Start:   Constraint synthesis
··End:     Constraint synthesis ....................................................173.935ms
··Start:   Inlining LCs
··End:     Inlining LCs ............................................................193.968ms
··Start:   Constructing evaluation domain
··End:     Constructing evaluation domain ..........................................289.709µs
··Start:   R1CS to QAP Instance Map with Evaluation
····Start:   Evaluate Lagrange coefficients
····End:     Evaluate Lagrange coefficients ........................................40.183ms
··End:     R1CS to QAP Instance Map with Evaluation ................................260.557ms
··Start:   Compute G2 table
··End:     Compute G2 table ........................................................254.382ms
··Start:   Calculate B G2
··End:     Calculate B G2 ..........................................................2.341s
··Start:   Compute G1 window table
··End:     Compute G1 window table .................................................66.168ms
··Start:   Generate the R1CS proving key
····Start:   Calculate A
····End:     Calculate A ...........................................................524.809ms
····Start:   Calculate B G1
····End:     Calculate B G1 ........................................................388.166ms
····Start:   Calculate H
····End:     Calculate H ...........................................................1.269s
····Start:   Calculate L
····End:     Calculate L ...........................................................526.624ms
··End:     Generate the R1CS proving key ...........................................2.737s
··Start:   Generate the R1CS verification key
··End:     Generate the R1CS verification key ......................................11.285ms
··Start:   Convert proving key elements to affine
··End:     Convert proving key elements to affine ..................................118.935ms
End:     Groth16::Generator ........................................................6.165s
```

</details>

<details>
  <summary>Release mode statics</summary>

```rust
Start:   Groth16::Generator
··Start:   Constraint synthesis
··End:     Constraint synthesis ....................................................19.548ms
··Start:   Inlining LCs
··End:     Inlining LCs ............................................................18.963ms
··Start:   Constructing evaluation domain
··End:     Constructing evaluation domain ..........................................10.750µs
··Start:   R1CS to QAP Instance Map with Evaluation
····Start:   Evaluate Lagrange coefficients
····End:     Evaluate Lagrange coefficients ........................................3.041ms
··End:     R1CS to QAP Instance Map with Evaluation ................................26.933ms
··Start:   Compute G2 table
··End:     Compute G2 table ........................................................7.242ms
··Start:   Calculate B G2
··End:     Calculate B G2 ..........................................................63.559ms
··Start:   Compute G1 window table
··End:     Compute G1 window table .................................................4.768ms
··Start:   Generate the R1CS proving key
····Start:   Calculate A
····End:     Calculate A ...........................................................30.257ms
····Start:   Calculate B G1
····End:     Calculate B G1 ........................................................22.394ms
····Start:   Calculate H
····End:     Calculate H ...........................................................86.160ms
····Start:   Calculate L
····End:     Calculate L ...........................................................30.473ms
··End:     Generate the R1CS proving key ...........................................170.395ms
··Start:   Generate the R1CS verification key
··End:     Generate the R1CS verification key ......................................419.125µs
··Start:   Convert proving key elements to affine
··End:     Convert proving key elements to affine ..................................7.249ms
End:     Groth16::Generator ........................................................320.064ms
```

</details>


Closes #8 