### PR TITLE
Compute A and B

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        example: [ext_wit_bench, groth_bench, dpp_test, msm_bench, dmsm_bench, local_dfft_test, dfft_test, dmsm_test]
+        example: [ext_wit_bench, groth_bench, dpp_test, msm_bench, dmsm_bench, local_dfft_test, dfft_test, dmsm_test, sha256]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Rust

--- a/groth16/examples/sha256.rs
+++ b/groth16/examples/sha256.rs
@@ -5,22 +5,21 @@ use ark_circom::{CircomBuilder, CircomConfig, CircomReduction};
 use ark_crypto_primitives::snark::SNARK;
 use ark_ec::pairing::Pairing;
 use ark_ec::CurveGroup;
-use ark_ff::{BigInt, MontFp};
+use ark_ff::BigInt;
+use ark_groth16::r1cs_to_qap::R1CSToQAP;
 use ark_groth16::{Groth16, Proof};
-use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
+use ark_poly::Radix2EvaluationDomain;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
-use ark_std::Zero;
-use ark_std::{cfg_chunks, cfg_into_iter, end_timer, start_timer};
+use ark_std::{cfg_chunks, cfg_into_iter, end_timer, start_timer, Zero};
 
 use dist_primitives::dmsm;
 use log::debug;
 use mpc_net::{LocalTestNet as Net, MpcNet, MultiplexedStreamID};
 
+use rand::SeedableRng;
 use secret_sharing::pss::PackedSharingParams;
 
-use groth16::{
-    ext_wit::d_ext_wit, proving_key::PackedProvingKeyShare, ConstraintDomain,
-};
+use groth16::proving_key::PackedProvingKeyShare;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -28,45 +27,10 @@ use rayon::prelude::*;
 async fn dsha256<E: Pairing, Net: MpcNet>(
     pp: &PackedSharingParams<E::ScalarField>,
     crs_share: &PackedProvingKeyShare<E>,
-    qap: groth16::qap::QAP<
-        E::ScalarField,
-        Radix2EvaluationDomain<E::ScalarField>,
-    >,
     a_share: &[E::ScalarField],
-    cd: &ConstraintDomain<E::ScalarField>,
+    h_share: &[E::ScalarField],
     net: &mut Net,
 ) -> (E::G1, E::G2, E::G1) {
-    // Add preprocessing vectors of size 4m/l
-    // process u and v to get ready for multiplication
-
-    // Field operations
-    // u, v, w -- m/l + m/l + m/l
-    // Compute IFFT(u)
-    // Compute FFT(u)
-    // Compute IFFT(v)
-    // Compute FFT(v)
-    // Compute IFFT(w)
-    // Compute FFT(w)
-    // u, v - 2m/l + 2m/l shares
-    // w - 2m/l shares
-    // t - 2m/l shares (Can be dropped in later by king so not contributing to memory)
-
-    // Former can be avoided if client provides 2Q evaluations of u,v,w instead of Q evaluations
-    // Computing h
-    // Compute h = (u.v - w).t -- 2m/l shares
-    // Send to king to pack desired coefficients of h
-
-    // Group operations
-    // Packed CRS drops in from the sky
-    // Do 5 MSMs to obtain shares of A, B and C
-    // Done
-
-    let rng = &mut ark_std::test_rng();
-
-    let h_share: Vec<E::ScalarField> =
-        d_ext_wit(qap.a, qap.b, qap.c, rng, pp, cd, net)
-            .await
-            .unwrap();
     debug!(
         "s:{}, v:{}, h:{}, w:{}, u:{}, a_share:{}, h_share:{}",
         crs_share.s.len(),
@@ -84,92 +48,58 @@ async fn dsha256<E: Pairing, Net: MpcNet>(
         dmsm::d_msm(&crs_share.s, a_share, pp, net, MultiplexedStreamID::One)
             .await
             .unwrap();
-    debug!("s done");
     let pi_b_share: E::G2 =
         dmsm::d_msm(&crs_share.v, a_share, pp, net, MultiplexedStreamID::One)
             .await
             .unwrap();
-    debug!("v done");
-    let pi_c_share1: E::G1 = dmsm::d_msm(
-        &crs_share.h,
-        &a_share[..crs_share.h.len()],
-        pp,
-        net,
-        MultiplexedStreamID::One,
-    )
-    .await
-    .unwrap();
-    debug!("h done");
-    let pi_c_share2: E::G1 = dmsm::d_msm(
-        &crs_share.w,
-        &a_share[..crs_share.w.len()],
-        pp,
-        net,
-        MultiplexedStreamID::One,
-    )
-    .await
-    .unwrap();
-    debug!("w done");
-    let pi_c_share3: E::G1 = dmsm::d_msm(
-        &crs_share.u,
-        &h_share[..crs_share.u.len()],
-        pp,
-        net,
-        MultiplexedStreamID::One,
-    )
-    .await
-    .unwrap();
-    debug!("u done");
-    let pi_c_share: E::G1 = pi_c_share1 + pi_c_share2 + pi_c_share3; //Additive notation for groups
+    // let pi_c_share1: E::G1 =
+    //     dmsm::d_msm(&crs_share.h, a_share, pp, net, MultiplexedStreamID::One)
+    //         .await
+    //         .unwrap();
+    // let pi_c_share2: E::G1 =
+    //     dmsm::d_msm(&crs_share.w, a_share, pp, net, MultiplexedStreamID::One)
+    //         .await
+    //         .unwrap();
+    // let pi_c_share3: E::G1 =
+    //     dmsm::d_msm(&crs_share.u, h_share, pp, net, MultiplexedStreamID::One)
+    //         .await
+    //         .unwrap();
+    // let pi_c_share: E::G1 = pi_c_share1 + pi_c_share2 + pi_c_share3; //Additive notation for groups
     end_timer!(msm_section);
 
-    debug!("Done");
     // Send pi_a_share, pi_b_share, pi_c_share to client
+    let pi_c_share = E::G1::zero();
     (pi_a_share, pi_b_share, pi_c_share)
 }
 
 fn pack_from_witness<E: Pairing>(
-    n: usize,
     pp: &PackedSharingParams<E::ScalarField>,
-    mut full_assignment: Vec<E::ScalarField>,
+    full_assignment: Vec<E::ScalarField>,
 ) -> Vec<Vec<E::ScalarField>> {
-    // ensure that full assignment is divisible by l
-    // by padding with zeros if necessary.
-    let full_assignment_len = full_assignment.len();
-    let remainder = full_assignment_len % pp.l;
-    let full_assignment = if remainder != 0 {
-        // push zero element to make it divisible by l
-        full_assignment
-            .extend_from_slice(&vec![E::ScalarField::zero(); pp.l - remainder]);
-        full_assignment
-    } else {
-        full_assignment
-    };
     let packed_assignments = cfg_chunks!(full_assignment, pp.l)
         .map(|chunk| pp.pack_from_public(chunk.to_vec()))
         .collect::<Vec<_>>();
 
-    cfg_into_iter!(0..n)
+    cfg_into_iter!(0..pp.n)
         .map(|i| {
             cfg_into_iter!(0..packed_assignments.len())
                 .map(|j| packed_assignments[j][i])
                 .collect::<Vec<_>>()
         })
-        .collect()
+        .collect::<Vec<_>>()
 }
 
 #[tokio::main]
 async fn main() {
     env_logger::builder().format_timestamp(None).init();
 
-    let n = 8;
     let cfg = CircomConfig::<Bn254>::new(
         "./fixtures/sha256/sha256_js/sha256.wasm",
         "./fixtures/sha256/sha256.r1cs",
     )
     .unwrap();
     let mut builder = CircomBuilder::new(cfg);
-    let rng = &mut ark_std::rand::thread_rng();
+    let rng = &mut ark_std::rand::rngs::StdRng::from_seed([42u8; 32]);
     builder.push_input("a", 1);
     builder.push_input("b", 2);
     let circuit = builder.setup();
@@ -184,51 +114,82 @@ async fn main() {
     assert!(cs.is_satisfied().unwrap());
     let matrices = cs.to_matrices().unwrap();
 
-    let qap = groth16::qap::qap::<Bn254Fr, Radix2EvaluationDomain<_>>(
-        &matrices,
-        &full_assignment,
-    )
+    let num_inputs = matrices.num_instance_variables;
+    let num_constraints = matrices.num_constraints;
+    let h = CircomReduction::witness_map_from_matrices::<
+        Bn254Fr,
+        Radix2EvaluationDomain<_>,
+    >(&matrices, num_inputs, num_constraints, &full_assignment)
     .unwrap();
-    let pp_g1 = PackedSharingParams::new(2);
-    let pp_g2 = PackedSharingParams::new(2);
+
+    let r = Bn254Fr::zero();
+    let s = Bn254Fr::zero();
+    let arkworks_proof = Groth16::<Bn254, CircomReduction>::create_proof_with_reduction_and_matrices(
+        &pk,
+        r,
+        s,
+        &matrices,
+        num_inputs,
+        num_constraints,
+        &full_assignment,
+    ).unwrap();
+
+    let pp = PackedSharingParams::new(2);
+    let pp_g1 = PackedSharingParams::new(pp.l);
+    let pp_g2 = PackedSharingParams::new(pp.l);
     let crs_shares =
         PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(
-            &pk, n, pp_g1, pp_g2,
+            &pk, pp_g1, pp_g2,
         );
     let crs_shares = Arc::new(crs_shares);
-    let pp = PackedSharingParams::<Bn254Fr>::new(2);
-    let a_shares = pack_from_witness::<Bn254>(n, &pp, full_assignment);
-    let network = Net::new_local_testnet(n).await.unwrap();
+    let a_shares =
+        pack_from_witness::<Bn254>(&pp, full_assignment[1..].to_vec());
+    let h_shares = pack_from_witness::<Bn254>(&pp, h);
+    let network = Net::new_local_testnet(pp.n).await.unwrap();
 
     let result = network
         .simulate_network_round(
-            (crs_shares, pp, qap, a_shares),
-            |mut net, (crs_shares, pp, qap, a_shares)| async move {
-                let cd = ConstraintDomain::new(qap.domain.size());
+            (crs_shares, pp, a_shares, h_shares),
+            |mut net, (crs_shares, pp, a_shares, h_shares)| async move {
                 let crs_share =
                     crs_shares.get(net.party_id() as usize).unwrap();
-                let a_share = a_shares[net.party_id() as usize].clone();
-                dsha256(&pp, crs_share, qap, &a_share, &cd, &mut net).await
+                let a_share = &a_shares[net.party_id() as usize];
+                let h_share = &h_shares[net.party_id() as usize];
+                dsha256(&pp, crs_share, a_share, h_share, &mut net).await
             },
         )
         .await;
-    let a = result[0].0;
-    let b = result[0].1;
-    let c = result[0].2;
-    for (i, (a_share, b_share, c_share)) in result.iter().enumerate() {
-        debug!("Party:{}", i);
-        debug!("a:{}", a_share);
-        debug!("b:{}", b_share);
-        debug!("c:{}", c_share);
-        debug!("---------------------");
-    }
-    // TODO: construct the proof
+    let (mut a, mut b, c) = result[0];
+    // These elements are needed to construct the full proof, they are part of the proving key.
+    // however, we can just send these values to the client, not the full proving key.
+    a += pk.a_query[0] + vk.alpha_g1;
+    b += pk.b_g2_query[0] + vk.beta_g2;
+    debug!("a:{}", a);
+    debug!("b:{}", b);
+    debug!("c:{}", c);
+    debug!("------------");
+    debug!("arkworks_a:{}", arkworks_proof.a);
+    debug!("arkworks_b:{}", arkworks_proof.b);
+    debug!("arkworks_c:{}", arkworks_proof.c);
+
+    let pvk = ark_groth16::verifier::prepare_verifying_key(&vk);
+    let verified = Groth16::<Bn254, CircomReduction>::verify_with_processed_vk(
+        &pvk,
+        &[BigInt!(
+            "72587776472194017031617589674261467945970986113287823188107011979"
+        )
+        .into()],
+        &arkworks_proof,
+    )
+    .unwrap();
+
+    assert!(verified, "Arkworks Proof verification failed!");
     let proof = Proof::<Bn254> {
         a: a.into_affine(),
         b: b.into_affine(),
-        c: c.into_affine(),
+        // TODO: replace this with the actual c from our computation
+        c: arkworks_proof.c,
     };
-    let pvk = ark_groth16::verifier::prepare_verifying_key(&vk);
     let verified = Groth16::<Bn254, CircomReduction>::verify_with_processed_vk(
         &pvk,
         &[BigInt!(

--- a/groth16/src/proving_key.rs
+++ b/groth16/src/proving_key.rs
@@ -34,7 +34,6 @@ where
     /// Each party will hold one share per PSS chunk.
     pub fn pack_from_arkworks_proving_key(
         pk: &ark_groth16::ProvingKey<E>,
-        n_parties: usize,
         pp_g1: PackedSharingParams<
             <<E as Pairing>::G1Affine as AffineRepr>::ScalarField,
         >,
@@ -44,20 +43,25 @@ where
     ) -> Vec<Self> {
         assert!(pp_g1.l == pp_g2.l);
         assert!(pp_g1.n == pp_g2.n);
+        let n = pp_g1.n;
 
         let pre_packed_s = cfg_into_iter!(pk.a_query.clone())
+            .skip(1)
             .map(Into::into)
             .collect::<Vec<_>>();
         let pre_packed_u = cfg_into_iter!(pk.h_query.clone())
+            .skip(1)
             .map(Into::into)
             .collect::<Vec<_>>();
         let pre_packed_w = cfg_into_iter!(pk.l_query.clone())
             .map(Into::into)
             .collect::<Vec<_>>();
         let pre_packed_h = cfg_into_iter!(pk.b_g1_query.clone())
+            .skip(1)
             .map(Into::into)
             .collect::<Vec<_>>();
         let pre_packed_v = cfg_into_iter!(pk.b_g2_query.clone())
+            .skip(1)
             .map(Into::into)
             .collect::<Vec<_>>();
 
@@ -77,7 +81,7 @@ where
             .map(|chunk| packexp_from_public::<E::G2>(chunk, &pp_g2))
             .collect::<Vec<_>>();
 
-        cfg_into_iter!(0..n_parties)
+        cfg_into_iter!(0..n)
             .map(|i| {
                 let s_shares = cfg_into_iter!(0..packed_s.len())
                     .map(|j| packed_s[j][i].into())
@@ -183,10 +187,9 @@ mod tests {
             .unwrap();
         let pp_g1 = PackedSharingParams::new(4);
         let pp_g2 = PackedSharingParams::new(4);
-        let n = 8;
         let shares =
             PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(
-                &pk, n, pp_g1, pp_g2,
+                &pk, pp_g1, pp_g2,
             );
         eprintln!("shares: {:?}", shares);
         // Do something with the shares


### PR DESCRIPTION
This PR correctly calculates the A and B group elements, and also tests this against the actual proof generated by Arkworks.

For this PR, we are using A and B generated from our calculation, and later on, we will use the C group elements from the actual arkworks proof to get our test pass.

In the next PR is to get C computed by us.