### PR TITLE
[feat] Re:Implement and expose Distributed Proof for groth16

### DIFF
--- a/groth16/src/prove.rs
+++ b/groth16/src/prove.rs
@@ -1,119 +1,137 @@
 #![allow(non_snake_case, clippy::too_many_arguments)]
 
-use ark_ec::{pairing::Pairing, CurveGroup};
-use ark_ff::{FftField, PrimeField};
+use ark_ec::pairing::Pairing;
 use dist_primitives::dmsm::d_msm;
 use mpc_net::{MpcNet, MpcNetError, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
 
 /// A = L.(N)^r.∏{i∈[0,m]}(S_i)^a_i
-pub async fn compute_A<
-    E: Pairing<G1Affine = F>,
-    F: FftField + PrimeField,
-    Net: MpcNet,
->(
-    L: E::G1,
-    N: E::G1,
-    r: F,
-    (s_pp, S): (PackedSharingParams<E::ScalarField>, Vec<E::G1Affine>),
-    a: Vec<E::ScalarField>,
-    net: &Net,
-    sid: MultiplexedStreamID,
-) -> Result<E::G1Affine, MpcNetError> {
-    // We use variables (L, N, (S_i){i∈[0,m]}) to denote elements in G1
-    // We also assume that all the servers computing the proof
-    // get L, N in the clear and only receive packed shares of the remaining elements
-    // specifically, each server gets a share of (S_i)^a_i for i∈[0,Q-1].
-    //
-    // Given packed shares of S_i and au_i terms, the servers can use πMSM (dmsm) to compute ∏{i∈[0,Q−1]}(S_i)^a_i.
-    // Since the output of MSM are regular shares, they can then be combined with L, N and regular shares
-    // of r to get regular shares of A.
+#[derive(Debug, Clone, Copy)]
+pub struct A<'a, E: Pairing> {
+    pub L: E::G1Affine,
+    pub N: E::G1Affine,
+    pub r: E::ScalarField,
+    pub pp: &'a PackedSharingParams<E::ScalarField>,
+    pub S: &'a [E::G1Affine],
+    pub a: &'a [E::ScalarField],
+}
 
-    // Calculate (N)^r
-    let v0 = N.into_affine().pow(r.into_bigint());
-    // Calculate L.(N)^r
-    let v1 = L.into_affine().mul(v0);
+impl<'a, E: Pairing> A<'a, E> {
+    /// Computes A
+    pub async fn compute<Net: MpcNet>(
+        self,
+        net: &Net,
+        sid: MultiplexedStreamID,
+    ) -> Result<E::G1, MpcNetError> {
+        // We use variables (L, N, (S_i){i∈[0,m]}) to denote elements in G1
+        // We also assume that all the servers computing the proof
+        // get L, N in the clear and only receive packed shares of the remaining elements
+        // specifically, each server gets a share of (S_i)^a_i for i∈[0,Q-1].
+        //
+        // Given packed shares of S_i and au_i terms, the servers can use πMSM (dmsm) to compute ∏{i∈[0,Q−1]}(S_i)^a_i.
+        // Since the output of MSM are regular shares, they can then be combined with L, N and regular shares
+        // of r to get regular shares of A.
 
-    // Calculate ∏{i∈[0,m]}(S_i)^a_i using dmsm
+        // Calculate (N)^r
+        let v0 = self.N * self.r;
+        // Calculate L.(N)^r
+        let v1 = self.L + v0;
 
-    let prod = d_msm::<E::G1, _>(&S, &a, &s_pp, net, sid).await?;
+        // Calculate ∏{i∈[0,m]}(S_i)^a_i using dmsm
+        let prod = d_msm::<E::G1, _>(self.S, self.a, self.pp, net, sid).await?;
 
-    Ok(prod.into_affine().mul(v1))
+        let A = v1 + prod;
+
+        Ok(A)
+    }
 }
 
 /// B = Z.(K)^s.∏{i∈[0,m]}(V_i)^a_i
-pub async fn compute_B<
-    E: Pairing<G2Affine = F>,
-    F: FftField + PrimeField,
-    Net: MpcNet,
->(
-    Z: E::G2,
-    K: E::G2,
-    s: F,
-    (v_pp, V): (PackedSharingParams<E::ScalarField>, Vec<E::G2Affine>),
-    a: Vec<E::ScalarField>,
-    net: &Net,
-    sid: MultiplexedStreamID,
-) -> Result<E::G2Affine, MpcNetError> {
-    // We use variables (Z, K, (V_i){i∈[0,m]}) to denote elements in G2
-    // We also assume that all the servers computing the proof
-    // get Z, K in the clear and only receive packed shares of the remaining elements
-    // specifically, each server gets a share of (V_i)^a_i for i∈[0,Q-1].
-    //
-    // Given packed shares of V_i and av_i terms, the servers can use πMSM (dmsm) to compute ∏{i∈[0,Q−1]}(V_i)^a_i.
-    // Since the output of MSM are regular shares, they can then be combined with Z, K and regular shares
-    // of s to get regular shares of A.
+#[derive(Debug, Clone, Copy)]
+pub struct B<'a, E: Pairing> {
+    pub Z: E::G2Affine,
+    pub K: E::G2Affine,
+    pub s: E::ScalarField,
+    pub pp: &'a PackedSharingParams<E::ScalarField>,
+    pub V: &'a [E::G2Affine],
+    pub a: &'a [E::ScalarField],
+}
 
-    // Calculate (K)^s
-    let v0 = K.into_affine().pow(s.into_bigint());
-    // Calculate Z.(K)^s
-    let v1 = Z.into_affine().mul(v0);
-    // Calculate ∏{i∈[0,m]}(V_i)^a_i using dmsm
-    let prod = d_msm::<E::G2, _>(&V, &a, &v_pp, net, sid).await?;
-    Ok(prod.into_affine().mul(v1))
+impl<'a, E: Pairing> B<'a, E> {
+    /// Computes B
+    pub async fn compute<Net: MpcNet>(
+        self,
+        net: &Net,
+        sid: MultiplexedStreamID,
+    ) -> Result<E::G2, MpcNetError> {
+        // We use variables (Z, K, (V_i){i∈[0,m]}) to denote elements in G2
+        // We also assume that all the servers computing the proof
+        // get Z, K in the clear and only receive packed shares of the remaining elements
+        // specifically, each server gets a share of (V_i)^a_i for i∈[0,Q-1].
+        //
+        // Given packed shares of V_i and av_i terms, the servers can use πMSM (dmsm) to compute ∏{i∈[0,Q−1]}(V_i)^a_i.
+        // Since the output of MSM are regular shares, they can then be combined with Z, K and regular shares
+        // of s to get regular shares of A.
+        // Calculate (K)^s
+        let v0 = self.K * self.s;
+        // Calculate Z.(K)^s
+        let v1 = self.Z + v0;
+        // Calculate ∏{i∈[0,m]}(V_i)^a_i using dmsm
+        let prod = d_msm::<E::G2, _>(self.V, self.a, self.pp, net, sid).await?;
+
+        let B = v1 + prod;
+
+        Ok(B)
+    }
 }
 
 /// C = (∏{i∈[l+1,m]}(W_i)^a_i)(∏{i∈[0,Q−2]}(U_i)^h_i).A^s.M^r.(∏{i∈[0,m]}(H_i)^a_i)^r
-pub async fn compute_C<
-    E: Pairing<G1Affine = F>,
-    F: FftField + PrimeField,
-    Net: MpcNet,
->(
-    A: E::G1Affine,
-    M: E::G1,
-    s: F,
-    r: F,
-    (w_pp, W): (PackedSharingParams<E::ScalarField>, Vec<E::G1Affine>),
-    (u_pp, U): (PackedSharingParams<E::ScalarField>, Vec<E::G1Affine>),
-    (h_pp, H): (PackedSharingParams<E::ScalarField>, Vec<E::G1Affine>),
-    a: Vec<E::ScalarField>,
-    h: Vec<E::ScalarField>,
-    net: &Net,
-) -> Result<E::G1Affine, MpcNetError> {
-    // We use variables (A, M, ∏{i∈[l+1,m]}(W_i)^a_i, ∏{i∈[0,Q−2]}(U_i)h_i, ∏{i∈[0,m]}(H_i)^a_i)
-    // to denote elements in G1. We also assume that all the servers computing the proof
-    // get A, M, s, r and h in the clear and only receive packed shares of the remaining elements.
+#[derive(Debug, Clone, Copy)]
+pub struct C<'a, E: Pairing> {
+    pub A: E::G1,
+    pub M: E::G1Affine,
+    pub s: E::ScalarField,
+    pub r: E::ScalarField,
+    pub pp: &'a PackedSharingParams<E::ScalarField>,
+    pub W: &'a [E::G1Affine],
+    pub U: &'a [E::G1Affine],
+    pub H: &'a [E::G1Affine],
+    pub a: &'a [E::ScalarField],
+    pub ax: &'a [E::ScalarField],
+    pub h: &'a [E::ScalarField],
+}
 
-    const CHANNEL0: MultiplexedStreamID = MultiplexedStreamID::Zero;
-    const CHANNEL1: MultiplexedStreamID = MultiplexedStreamID::One;
-    const CHANNEL2: MultiplexedStreamID = MultiplexedStreamID::Two;
+impl<'a, E: Pairing> C<'a, E> {
+    /// Computes C
+    pub async fn compute<Net: MpcNet>(
+        self,
+        net: &Net,
+    ) -> Result<E::G1, MpcNetError> {
+        // We use variables (A, M, ∏{i∈[l+1,m]}(W_i)^a_i, ∏{i∈[0,Q−2]}(U_i)h_i, ∏{i∈[0,m]}(H_i)^a_i)
+        // to denote elements in G1. We also assume that all the servers computing the proof
+        // get A, M, s, r and h in the clear and only receive packed shares of the remaining elements.
 
-    // Calculate ∏{i∈[l+1,m]}(W_i)^a_i using dmsm
-    let w = d_msm::<E::G1, _>(&W, &a, &w_pp, net, CHANNEL0);
-    // Calculate ∏{i∈[0,Q−2]}(U_i)^h_i using dmsm
-    let u = d_msm::<E::G1, _>(&U, &h, &u_pp, net, CHANNEL1);
-    // Calculate ∏{i∈[0,m]}(H_i)^a_i using dmsm
-    let h = d_msm::<E::G1, _>(&H, &a, &h_pp, net, CHANNEL2);
+        const CHANNEL0: MultiplexedStreamID = MultiplexedStreamID::Zero;
+        const CHANNEL1: MultiplexedStreamID = MultiplexedStreamID::One;
+        const CHANNEL2: MultiplexedStreamID = MultiplexedStreamID::Two;
 
-    let (w, u, h) = tokio::try_join!(w, u, h)?;
+        // Calculate ∏{i∈[l+1,m]}(W_i)^a_i using dmsm
+        let w = d_msm::<E::G1, _>(self.W, self.ax, self.pp, net, CHANNEL0);
+        // Calculate ∏{i∈[0,Q−2]}(U_i)^h_i using dmsm
+        let u = d_msm::<E::G1, _>(self.U, self.h, self.pp, net, CHANNEL1);
+        // Calculate ∏{i∈[0,m]}(H_i)^a_i using dmsm
+        let h = d_msm::<E::G1, _>(self.H, self.a, self.pp, net, CHANNEL2);
 
-    // Calculate A^s
-    let v0 = A.pow(s.into_bigint());
-    // Calculate M^r
-    let v1 = M.into_affine().pow(r.into_bigint());
-    // Calculate (∏{i∈[0,m]}(H_i)^a_i)^r
-    let v2 = h.into_affine().pow(r.into_bigint());
-    // finally compute C
-    let c = w.into_affine().mul(u.into_affine()).mul(v0).mul(v1).mul(v2);
-    Ok(c)
+        let (w, u, h) = tokio::try_join!(w, u, h)?;
+
+        // Calculate A^s
+        let v0 = self.A * self.s;
+        // Calculate M^r
+        let v1 = self.M * self.r;
+        // Calculate (∏{i∈[0,m]}(H_i)^a_i)^r
+        let v2 = h * self.r;
+        // finally compute C
+        let C = w + u + v0 + v1 + v2;
+        Ok(C)
+    }
 }

--- a/groth16/src/proving_key.rs
+++ b/groth16/src/proving_key.rs
@@ -26,7 +26,7 @@ pub struct PackedProvingKeyShare<E: Pairing> {
 
 impl<E: Pairing> PackedProvingKeyShare<E>
 where
-    E::ScalarField: FftField,
+    E::ScalarField: FftField + PrimeField,
     <<E as Pairing>::G1Affine as AffineRepr>::ScalarField: FftField,
     E::BaseField: PrimeField,
 {


### PR DESCRIPTION
This pull request rewrites the correct implementation of A, B, and C for the distributed proof generation for Groth16. Adding randomness and zk to the mix does take into account the Zero-Knowledge components.

I did also update the sha256 example to use the new implementation, with the zk components removed (for now).