### PR TITLE
`secret-sharing` cleanup

### DIFF
--- a/dist-primitives/examples/dfft_test.rs
+++ b/dist-primitives/examples/dfft_test.rs
@@ -40,16 +40,10 @@ pub async fn d_fft_test<F: FftField + PrimeField, Net: MpcNet>(
 
     // Rearranging x
 
-    let peval_share = d_fft(
-        pcoeff_share,
-        false,
-        dom,
-        pp,
-        net,
-        MultiplexedStreamID::One,
-    )
-    .await
-    .unwrap();
+    let peval_share =
+        d_fft(pcoeff_share, false, dom, pp, net, MultiplexedStreamID::One)
+            .await
+            .unwrap();
 
     // Send to king who reconstructs and checks the answer
     let result = net

--- a/dist-primitives/examples/dfft_test.rs
+++ b/dist-primitives/examples/dfft_test.rs
@@ -14,6 +14,7 @@ pub async fn d_fft_test<F: FftField + PrimeField, Net: MpcNet>(
     dom: &Radix2EvaluationDomain<F>,
     net: &Net,
 ) {
+    let rng = &mut ark_std::test_rng();
     let mbyl: usize = dom.size() / pp.l;
     // We apply FFT on this vector
     // let mut x = vec![F::ONE; cd.m];
@@ -28,9 +29,10 @@ pub async fn d_fft_test<F: FftField + PrimeField, Net: MpcNet>(
     fft_in_place_rearrange(&mut x);
     let mut pcoeff: Vec<Vec<F>> = Vec::new();
     for i in 0..mbyl {
-        pcoeff
-            .push(x.iter().skip(i).step_by(mbyl).cloned().collect::<Vec<_>>());
-        pp.pack_from_public_in_place(&mut pcoeff[i]);
+        let secrets = x.iter().skip(i).step_by(mbyl).cloned().collect::<Vec<_>>();
+        pcoeff.push(
+            pp.pack(secrets, rng)
+        );
     }
 
     let pcoeff_share = pcoeff

--- a/dist-primitives/examples/dfft_test.rs
+++ b/dist-primitives/examples/dfft_test.rs
@@ -29,10 +29,9 @@ pub async fn d_fft_test<F: FftField + PrimeField, Net: MpcNet>(
     fft_in_place_rearrange(&mut x);
     let mut pcoeff: Vec<Vec<F>> = Vec::new();
     for i in 0..mbyl {
-        let secrets = x.iter().skip(i).step_by(mbyl).cloned().collect::<Vec<_>>();
-        pcoeff.push(
-            pp.pack(secrets, rng)
-        );
+        let secrets =
+            x.iter().skip(i).step_by(mbyl).cloned().collect::<Vec<_>>();
+        pcoeff.push(pp.pack(secrets, rng));
     }
 
     let pcoeff_share = pcoeff

--- a/dist-primitives/examples/dfft_test.rs
+++ b/dist-primitives/examples/dfft_test.rs
@@ -43,8 +43,6 @@ pub async fn d_fft_test<F: FftField + PrimeField, Net: MpcNet>(
     let peval_share = d_fft(
         pcoeff_share,
         false,
-        1,
-        false,
         dom,
         pp,
         net,

--- a/dist-primitives/examples/dmsm_test.rs
+++ b/dist-primitives/examples/dmsm_test.rs
@@ -3,7 +3,6 @@ use ark_ec::CurveGroup;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_std::UniformRand;
 use dist_primitives::dmsm::d_msm;
-use dist_primitives::dmsm::packexp_from_public;
 use mpc_net::{LocalTestNet as Net, MpcNet, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
 
@@ -32,7 +31,7 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
 
     let x_share: Vec<G> = x_pub
         .chunks(pp.l)
-        .map(|s| packexp_from_public(s, pp)[net.party_id() as usize])
+        .map(|s| pp.pack(s.to_vec(), rng)[net.party_id() as usize])
         .collect();
 
     let y_share: Vec<G::ScalarField> = y_pub

--- a/dist-primitives/examples/dmsm_test.rs
+++ b/dist-primitives/examples/dmsm_test.rs
@@ -12,7 +12,6 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
     dom: &Radix2EvaluationDomain<G::ScalarField>,
     net: &Net,
 ) {
-    // let m = pp.l*4;
     let mbyl: usize = dom.size() / pp.l;
     println!(
         "m: {}, mbyl: {}, party_id: {}",
@@ -38,7 +37,7 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
 
     let y_share: Vec<G::ScalarField> = y_pub
         .chunks(pp.l)
-        .map(|s| pp.pack_from_public(s.to_vec())[net.party_id() as usize])
+        .map(|s| pp.pack(s.to_vec(), rng)[net.party_id() as usize])
         .collect();
 
     let x_pub_aff: Vec<G::Affine> = x_pub.iter().map(|s| (*s).into()).collect();

--- a/dist-primitives/examples/msm_bench.rs
+++ b/dist-primitives/examples/msm_bench.rs
@@ -21,7 +21,7 @@ pub fn msm_test<G: CurveGroup>(dom: &Radix2EvaluationDomain<G::ScalarField>) {
 }
 
 fn main() {
-    for i in 10..20 {
+    for i in 10..15 {
         let dom = Radix2EvaluationDomain::<Fr>::new(1 << i).unwrap();
         println!("domain size: {}", dom.size());
         msm_test::<ark_bls12_377::G1Projective>(&dom);

--- a/dist-primitives/src/dfft/mod.rs
+++ b/dist-primitives/src/dfft/mod.rs
@@ -177,7 +177,7 @@ async fn fft2_with_rearrange<F: FftField + PrimeField, Net: MpcSerNet>(
     sid: MultiplexedStreamID,
 ) -> Result<Vec<F>, MpcNetError> {
     // King applies FFT2 with rearrange
-
+    let rng = &mut ark_std::test_rng();
     let mbyl = px.len();
 
     let received_shares = net.send_to_king(&px, sid).await?;
@@ -209,12 +209,13 @@ async fn fft2_with_rearrange<F: FftField + PrimeField, Net: MpcSerNet>(
             for i in 0..s1.len() / pp.l {
                 out_shares.push(
                     // This will cause issues with memory benchmarking since it assumes everyone creates this instead of receiving it from dealer
-                    pp.pack_from_public(
+                    pp.pack(
                         s1.iter()
                             .skip(i)
                             .step_by(s1.len() / pp.l)
                             .cloned()
                             .collect::<Vec<_>>(),
+                        rng,
                     ),
                 );
             }
@@ -264,44 +265,31 @@ mod tests {
         let pp = PackedSharingParams::<F>::new(L);
         let constraint = Radix2EvaluationDomain::<F>::new(M).unwrap();
         let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
-        let mut x = (0..M).map(|_| F::rand(rng)).collect::<Vec<_>>();
-        eprint!("x = [");
-        (0..M).for_each(|i| {
-            eprint!("{}", x[i]);
-            if i != M - 1 {
-                eprint!(", ");
-            }
-        });
-        eprintln!("]");
+        let mut poly_evals = (0..M).map(|_| F::rand(rng)).collect::<Vec<_>>();
 
-        eprintln!("Computed x evals done ...");
-        eprintln!("Computing actual x evals by using ifft ...");
-        let actual_x_evals = constraint.ifft(&x);
-        eprintln!("Actual x coeff done ...");
+        let poly_coeffs = constraint.ifft(&poly_evals);
 
-        fft_in_place_rearrange(&mut x);
-        let mut pevals: Vec<Vec<F>> = Vec::new();
+        fft_in_place_rearrange(&mut poly_evals);
+        let mut pack_evals: Vec<Vec<F>> = Vec::new();
         for i in 0..M / pp.l {
-            pevals.push(
-                x.iter()
-                    .skip(i)
-                    .step_by(M / pp.l)
-                    .cloned()
-                    .collect::<Vec<_>>(),
-            );
-            pp.pack_from_public_in_place(&mut pevals[i]);
+            let secrets = poly_evals
+                .iter()
+                .skip(i)
+                .step_by(M / pp.l)
+                .cloned()
+                .collect::<Vec<_>>();
+            pack_evals.push(pp.pack(secrets, rng));
         }
 
-        eprintln!("Running d_ifft ...");
         let result = network
             .simulate_network_round(
-                (pevals, pp, constraint),
-                |net, (pcoeff, pp, constraint)| async move {
+                (pack_evals, pp, constraint),
+                |net, (pack_evals, pp, constraint)| async move {
                     let idx = net.party_id() as usize;
-                    let peval_share =
-                        pcoeff.iter().map(|x| x[idx]).collect::<Vec<_>>();
+                    let pack_eval =
+                        pack_evals.iter().map(|x| x[idx]).collect::<Vec<_>>();
                     d_ifft(
-                        peval_share,
+                        pack_eval,
                         false,
                         &constraint,
                         F::one(),
@@ -314,37 +302,13 @@ mod tests {
                 },
             )
             .await;
-        eprintln!("d_ifft done ...");
-        eprintln!("Computing x evals from the shares ...");
-        let computed_x_evals = transpose(result)
+
+        let computed_poly_coeffs = transpose(result)
             .into_iter()
             .flat_map(|x| pp.unpack(x))
             .collect::<Vec<_>>();
 
-        eprintln!("Comparing the computed x eval with actual x eval ...");
-        eprintln!("```");
-        for i in 0..M {
-            eprintln!("ACTL: {}", actual_x_evals[i]);
-            eprintln!("COMP: {}", computed_x_evals[i]);
-            if actual_x_evals[i] == computed_x_evals[i] {
-                eprintln!("..{i}th element Matched ✅");
-            } else {
-                eprintln!("..{i}th element Mismatched ❌");
-                // search for the element in actual_x_coeff
-                let found = computed_x_evals
-                    .iter()
-                    .position(|&x| x == actual_x_evals[i]);
-                match found {
-                    Some(i) => eprintln!(
-                        "....However, it has been found at index: {i} ⚠️"
-                    ),
-                    None => eprintln!("....and Not found at all 🤔"),
-                }
-            }
-        }
-        eprintln!("```");
-
-        assert_eq!(actual_x_evals, computed_x_evals);
+        assert_eq!(poly_coeffs, computed_poly_coeffs);
     }
 
     #[tokio::test]
@@ -353,40 +317,31 @@ mod tests {
         let pp = PackedSharingParams::<F>::new(L);
         let constraint = Radix2EvaluationDomain::<F>::new(M).unwrap();
         let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
-        let mut x = (0..M).map(|_| F::rand(rng)).collect::<Vec<_>>();
-        let actual_x_coeff = constraint.fft(&x);
-        eprint!("x = [");
-        (0..M).for_each(|i| {
-            eprint!("{}", x[i]);
-            if i != M - 1 {
-                eprint!(", ");
-            }
-        });
-        eprintln!("]");
+        let mut poly_coeffs = (0..M).map(|_| F::rand(rng)).collect::<Vec<_>>();
+        let poly_evals = constraint.fft(&poly_coeffs);
 
-        fft_in_place_rearrange(&mut x);
+        fft_in_place_rearrange(&mut poly_coeffs);
 
-        let mut pcoeff: Vec<Vec<F>> = Vec::new();
+        let mut pack_coeffs: Vec<Vec<F>> = Vec::new();
         for i in 0..M / pp.l {
-            pcoeff.push(
-                x.iter()
-                    .skip(i)
-                    .step_by(M / pp.l)
-                    .cloned()
-                    .collect::<Vec<_>>(),
-            );
-            pp.pack_from_public_in_place(&mut pcoeff[i]);
+            let secrets = poly_coeffs
+                .iter()
+                .skip(i)
+                .step_by(M / pp.l)
+                .cloned()
+                .collect::<Vec<_>>();
+            pack_coeffs.push(pp.pack(secrets, rng));
         }
-        eprintln!("Running d_fft ...");
+
         let result = network
             .simulate_network_round(
-                (pcoeff, pp, constraint),
-                |net, (pcoeff, pp, constraint)| async move {
+                (pack_coeffs, pp, constraint),
+                |net, (pack_coeffs, pp, constraint)| async move {
                     let idx = net.party_id() as usize;
-                    let pcoeff_share =
-                        pcoeff.iter().map(|x| x[idx]).collect::<Vec<_>>();
+                    let pack_coeff =
+                        pack_coeffs.iter().map(|x| x[idx]).collect::<Vec<_>>();
                     d_fft(
-                        pcoeff_share,
+                        pack_coeff,
                         false,
                         &constraint,
                         &pp,
@@ -399,36 +354,14 @@ mod tests {
             )
             .await;
 
-        let computed_x_coeff = transpose(result)
+        let computed_poly_evals = transpose(result)
             .into_iter()
             .flat_map(|x| pp.unpack(x))
             .collect::<Vec<_>>();
 
-        eprintln!("Comparing the computed x coeff with actual x coeff ...");
-        eprintln!("```");
-        for i in 0..M {
-            eprintln!("ACTL: {}", actual_x_coeff[i]);
-            eprintln!("COMP: {}", computed_x_coeff[i]);
-            if actual_x_coeff[i] == computed_x_coeff[i] {
-                eprintln!("..{i}th element Matched ✅");
-            } else {
-                eprintln!("..{i}th element Mismatched ❌");
-                // search for the element in actual_x_coeff
-                let found = computed_x_coeff
-                    .iter()
-                    .position(|&x| x == actual_x_coeff[i]);
-                match found {
-                    Some(i) => eprintln!(
-                        "....However, it has been found at index: {i} ⚠️"
-                    ),
-                    None => eprintln!("....and Not found at all 🤔"),
-                }
-            }
-        }
-        eprintln!("```");
-        assert_eq!(actual_x_coeff, computed_x_coeff);
+        assert_eq!(poly_evals, computed_poly_evals);
     }
-
+    /*
     #[tokio::test]
     async fn d_ifftxd_fft_works() {
         let rng = &mut ark_std::test_rng();
@@ -610,4 +543,5 @@ mod tests {
 
         assert_eq!(expected_x, computed_x);
     }
+    */
 }

--- a/dist-primitives/src/dfft/mod.rs
+++ b/dist-primitives/src/dfft/mod.rs
@@ -360,7 +360,7 @@ mod tests {
 
         assert_eq!(poly_evals, computed_poly_evals);
     }
-    
+
     #[tokio::test]
     async fn d_ifftxd_fft_works() {
         let rng = &mut ark_std::test_rng();
@@ -413,7 +413,7 @@ mod tests {
                 },
             )
             .await;
-        
+
         let computed_poly_evals = transpose(result)
             .into_iter()
             .flat_map(|x| pp.unpack(x))
@@ -421,7 +421,7 @@ mod tests {
 
         assert_eq!(expected_evals, computed_poly_evals);
     }
-    
+
     #[tokio::test]
     async fn coset_d_ifftxd_fft_works() {
         let rng = &mut ark_std::test_rng();
@@ -509,5 +509,4 @@ mod tests {
 
         assert_eq!(expected_poly_evals, computed_poly_evals);
     }
-    
 }

--- a/dist-primitives/src/dfft/mod.rs
+++ b/dist-primitives/src/dfft/mod.rs
@@ -197,7 +197,7 @@ async fn fft2_with_rearrange<F: FftField + PrimeField, Net: MpcSerNet>(
 
         fft2_in_place(&mut s1, pp, gen, &net); // s1 constrains final output now
 
-        if !(g == F::one()) {
+        if g != F::one() {
             Radix2EvaluationDomain::<F>::distribute_powers(&mut s1, g);
         }
 

--- a/dist-primitives/src/dmsm/mod.rs
+++ b/dist-primitives/src/dmsm/mod.rs
@@ -148,7 +148,6 @@ mod tests {
     #[tokio::test]
     async fn pack_unpack2_test() {
         let net = LocalTestNet::new_local_testnet(4).await.unwrap();
-
         net.simulate_network_round((), |net, _| async move {
             let pp = PackedSharingParams::<F>::new(L);
             let rng = &mut ark_std::test_rng();
@@ -171,7 +170,7 @@ mod tests {
 
             let fshares: Vec<Vec<F>> = fsecrets
                 .chunks(L)
-                .map(|s| pp.pack_from_public(s.to_vec()))
+                .map(|s| pp.pack(s.to_vec(), rng))
                 .collect();
 
             let gshares = transpose(gshares);

--- a/dist-primitives/src/dmsm/mod.rs
+++ b/dist-primitives/src/dmsm/mod.rs
@@ -1,71 +1,7 @@
 use crate::channel::MpcSerNet;
-use ark_ec::{CurveGroup, Group};
-use ark_poly::EvaluationDomain;
+use ark_ec::CurveGroup;
 use mpc_net::{MpcNetError, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
-
-pub fn unpackexp<G: Group, Net: MpcSerNet>(
-    mut shares: Vec<G>,
-    degree2: bool,
-    pp: &PackedSharingParams<G::ScalarField>,
-    _net: &Net,
-) -> Vec<G> {
-    // interpolate shares
-    pp.share.ifft_in_place(&mut shares);
-
-    // Simplified this assertion using a zero check in the last n - d - 1 entries
-
-    #[cfg(debug_assertions)]
-    {
-        let n = _net.n_parties();
-        let d: usize = if degree2 {
-            2 * (pp.t + pp.l)
-        } else {
-            pp.t + pp.l
-        };
-
-        for share in shares.iter().take(n).skip(d + 1) {
-            debug_assert!(
-                share.is_zero(),
-                "Polynomial has degree > degree bound {})",
-                d
-            );
-        }
-    }
-
-    // Evaluate the polynomial on the coset to recover secrets
-    if degree2 {
-        pp.secret2.fft_in_place(&mut shares);
-        shares[0..pp.l * 2]
-            .iter()
-            .step_by(2)
-            .copied()
-            .collect::<Vec<_>>()
-    } else {
-        pp.secret.fft_in_place(&mut shares);
-        shares[0..pp.l].to_vec()
-    }
-}
-
-pub fn packexp_from_public_in_place<G: Group>(
-    secrets: &mut Vec<G>,
-    pp: &PackedSharingParams<G::ScalarField>,
-) {
-    // interpolate secrets
-    pp.secret.ifft_in_place(secrets);
-
-    // evaluate polynomial to get shares
-    pp.share.fft_in_place(secrets);
-}
-
-pub fn packexp_from_public<G: Group>(
-    secrets: &[G],
-    pp: &PackedSharingParams<G::ScalarField>,
-) -> Vec<G> {
-    let mut result = secrets.to_vec();
-    packexp_from_public_in_place(&mut result, pp);
-    result
-}
 
 pub async fn d_msm<G: CurveGroup, Net: MpcSerNet>(
     bases: &[G::Affine],
@@ -78,20 +14,20 @@ pub async fn d_msm<G: CurveGroup, Net: MpcSerNet>(
     // Eventually we do have to convert to Projective but this will be pp.l group elements instead of m()
 
     // First round of local computation done by parties
-    assert_eq!(bases.len(), scalars.len());
+    debug_assert_eq!(bases.len(), scalars.len());
     log::debug!("bases: {}, scalars: {}", bases.len(), scalars.len());
     let c_share = G::msm(bases, scalars)?;
+    
     // Now we do degree reduction -- psstoss
     // Send to king who reduces and sends shamir shares (not packed).
     // Should be randomized. First convert to projective share.
-
     let n_parties = net.n_parties();
     let king_answer: Option<Vec<G>> = net
         .send_to_king(&c_share, sid)
         .await?
         .map(|shares: Vec<G>| {
             // TODO: Mask with random values.
-            let output: G = unpackexp(shares, true, pp, &net).iter().sum();
+            let output: G = pp.unpack2(shares).iter().sum();
             vec![output; n_parties]
         });
 
@@ -110,85 +46,71 @@ mod tests {
 
     use ark_bls12_377::G1Affine;
     use ark_bls12_377::G1Projective as G1P;
-    use mpc_net::LocalTestNet;
 
     type F = <ark_ec::short_weierstrass::Projective<
         <ark_bls12_377::Config as Bls12Config>::G1Config,
     > as Group>::ScalarField;
 
-    use crate::dmsm::packexp_from_public;
-    use crate::dmsm::unpackexp;
     use crate::utils::pack::transpose;
 
     const L: usize = 2;
     const N: usize = L * 4;
-    // const T:usize = N/2 - L - 1;
     const M: usize = 1 << 8;
 
     #[tokio::test]
     async fn pack_unpack_test() {
-        println!("pack_unpack_test");
-        let net = LocalTestNet::new_local_testnet(4).await.unwrap();
+        let pp = PackedSharingParams::<F>::new(L);
+        let rng = &mut ark_std::test_rng();
+        let secrets: [G1P; L] = UniformRand::rand(rng);
+        let secrets = secrets.to_vec();
 
-        println!("net init done");
-
-        net.simulate_network_round((), |net, _| async move {
-            let pp = PackedSharingParams::<F>::new(L);
-            let rng = &mut ark_std::test_rng();
-            let secrets: [G1P; L] = UniformRand::rand(rng);
-            let secrets = secrets.to_vec();
-
-            let shares = packexp_from_public(&secrets, &pp);
-            let result = unpackexp(shares, false, &pp, &net);
-            assert_eq!(secrets, result);
-        })
-        .await;
+        let shares = pp.pack(secrets.clone(), rng);
+        let result = pp.unpack(shares);
+        assert_eq!(secrets, result);
     }
-
+    
     #[tokio::test]
     async fn pack_unpack2_test() {
-        let net = LocalTestNet::new_local_testnet(4).await.unwrap();
-        net.simulate_network_round((), |net, _| async move {
-            let pp = PackedSharingParams::<F>::new(L);
-            let rng = &mut ark_std::test_rng();
+    
+        let pp = PackedSharingParams::<F>::new(L);
+        let rng = &mut ark_std::test_rng();
 
-            let gsecrets: [G1P; M] = [G1P::rand(rng); M];
-            let gsecrets = gsecrets.to_vec();
+        let gsecrets: [G1P; M] = [G1P::rand(rng); M];
+        let gsecrets = gsecrets.to_vec();
 
-            let fsecrets: [F; M] = [F::from(1_u32); M];
-            let fsecrets = fsecrets.to_vec();
+        let fsecrets: [F; M] = [F::from(1_u32); M];
+        let fsecrets = fsecrets.to_vec();
 
-            ///////////////////////////////////////
-            let gsecrets_aff: Vec<G1Affine> =
-                gsecrets.iter().map(|s| (*s).into()).collect();
-            let expected = G1P::msm(&gsecrets_aff, &fsecrets).unwrap();
-            ///////////////////////////////////////
-            let gshares: Vec<Vec<G1P>> = gsecrets
-                .chunks(L)
-                .map(|s| packexp_from_public(s, &pp))
-                .collect();
+        ///////////////////////////////////////
+        let gsecrets_aff: Vec<G1Affine> =
+            gsecrets.iter().map(|s| (*s).into()).collect();
+        let expected = G1P::msm(&gsecrets_aff, &fsecrets).unwrap();
+        ///////////////////////////////////////
+        let gshares: Vec<Vec<G1P>> = gsecrets
+            .chunks(L)
+            .map(|s| pp.pack(s.to_vec(), rng))
+            .collect();
 
-            let fshares: Vec<Vec<F>> = fsecrets
-                .chunks(L)
-                .map(|s| pp.pack(s.to_vec(), rng))
-                .collect();
+        let fshares: Vec<Vec<F>> = fsecrets
+            .chunks(L)
+            .map(|s| pp.pack(s.to_vec(), rng))
+            .collect();
 
-            let gshares = transpose(gshares);
-            let fshares = transpose(fshares);
+        let gshares = transpose(gshares);
+        let fshares = transpose(fshares);
 
-            let mut result = vec![G1P::zero(); N];
+        let mut result = vec![G1P::zero(); pp.n];
 
-            for i in 0..N {
-                let temp_aff: Vec<
-                    <ark_ec::short_weierstrass::Projective<
-                        <ark_bls12_377::Config as Bls12Config>::G1Config,
-                    > as CurveGroup>::Affine,
-                > = gshares[i].iter().map(|s| (*s).into()).collect();
-                result[i] = G1P::msm(&temp_aff, &fshares[i]).unwrap();
-            }
-            let result: G1P = unpackexp(result, true, &pp, &net).iter().sum();
-            assert_eq!(expected, result);
-        })
-        .await;
+        for i in 0..N {
+            let temp_aff: Vec<
+                <ark_ec::short_weierstrass::Projective<
+                    <ark_bls12_377::Config as Bls12Config>::G1Config,
+                > as CurveGroup>::Affine,
+            > = gshares[i].iter().map(|s| (*s).into()).collect();
+            result[i] = G1P::msm(&temp_aff, &fshares[i]).unwrap();
+        }
+        let result: G1P = pp.unpack2(result).iter().sum();
+        assert_eq!(expected, result);
     }
+    
 }

--- a/dist-primitives/src/dmsm/mod.rs
+++ b/dist-primitives/src/dmsm/mod.rs
@@ -78,6 +78,7 @@ pub async fn d_msm<G: CurveGroup, Net: MpcSerNet>(
     // Eventually we do have to convert to Projective but this will be pp.l group elements instead of m()
 
     // First round of local computation done by parties
+    assert_eq!(bases.len(), scalars.len());
     log::debug!("bases: {}, scalars: {}", bases.len(), scalars.len());
     let c_share = G::msm(bases, scalars)?;
     // Now we do degree reduction -- psstoss

--- a/dist-primitives/src/dmsm/mod.rs
+++ b/dist-primitives/src/dmsm/mod.rs
@@ -17,7 +17,7 @@ pub async fn d_msm<G: CurveGroup, Net: MpcSerNet>(
     debug_assert_eq!(bases.len(), scalars.len());
     log::debug!("bases: {}, scalars: {}", bases.len(), scalars.len());
     let c_share = G::msm(bases, scalars)?;
-    
+
     // Now we do degree reduction -- psstoss
     // Send to king who reduces and sends shamir shares (not packed).
     // Should be randomized. First convert to projective share.
@@ -68,10 +68,9 @@ mod tests {
         let result = pp.unpack(shares);
         assert_eq!(secrets, result);
     }
-    
+
     #[tokio::test]
     async fn pack_unpack2_test() {
-    
         let pp = PackedSharingParams::<F>::new(L);
         let rng = &mut ark_std::test_rng();
 
@@ -112,5 +111,4 @@ mod tests {
         let result: G1P = pp.unpack2(result).iter().sum();
         assert_eq!(expected, result);
     }
-    
 }

--- a/dist-primitives/src/utils/deg_red.rs
+++ b/dist-primitives/src/utils/deg_red.rs
@@ -1,4 +1,7 @@
-use ark_ff::{FftField, PrimeField};
+use ark_ff::FftField;
+use ark_poly::domain::DomainCoeff;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::UniformRand;
 use mpc_net::{MpcNetError, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
 
@@ -7,22 +10,64 @@ use crate::channel::MpcSerNet;
 use super::pack::transpose;
 
 /// Reduces the degree of a poylnomial with the help of king
-pub async fn deg_red<F: FftField + PrimeField, Net: MpcSerNet>(
-    px: Vec<F>,
+pub async fn deg_red<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize + UniformRand, Net: MpcSerNet>(
+    x_share: Vec<T>,
     pp: &PackedSharingParams<F>,
     net: &Net,
     sid: MultiplexedStreamID,
-) -> Result<Vec<F>, MpcNetError> {
-    let received_shares = net.send_to_king(&px, sid).await?;
-    let king_answer: Option<Vec<Vec<F>>> =
-        received_shares.map(|px_shares: Vec<Vec<F>>| {
-            let mut px_shares = transpose(px_shares);
-            for px_share in &mut px_shares {
-                pp.unpack2_in_place(px_share);
-                pp.pack_from_public_in_place(px_share);
+) -> Result<Vec<T>, MpcNetError> {
+    let received_shares = net.send_to_king(&x_share, sid).await?;
+    let king_answer: Option<Vec<Vec<T>>> =
+        received_shares.map(|x_shares: Vec<Vec<T>>| {
+            let mut x_shares = transpose(x_shares);
+            
+            for i in 0..x_shares.len() {
+                let xi: Vec<T> = pp.unpack2(x_shares[i].clone());
+                x_shares[i] = pp.pack(xi, &mut rand::thread_rng());
+                // pp.unpack2_in_place(px_share);
+                // pp.pack_from_public_in_place(px_share);
             }
-            transpose(px_shares)
+            transpose(x_shares)
         });
 
     net.recv_from_king(king_answer, sid).await
+}
+
+#[cfg(test)]
+mod tests{
+    use mpc_net::{LocalTestNet, MultiplexedStreamID};
+    use secret_sharing::pss::PackedSharingParams;
+    use ark_bls12_377::Fr as F;
+    use ark_std::UniformRand;
+    use mpc_net::MpcNet;
+
+    use crate::utils::{deg_red::deg_red, pack::transpose};
+
+    const L: usize = 4;
+    #[tokio::test]
+    async fn test_deg_red() {
+        let pp = PackedSharingParams::<F>::new(L);
+        let rng = &mut ark_std::test_rng();
+        let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
+        
+        let secrets: [F; L] = UniformRand::rand(rng);
+        let secrets = secrets.to_vec();
+        let expected: Vec<F> = secrets.iter().map(|x| (*x) * (*x)).collect();
+
+        let shares = pp.pack(secrets, rng);
+        let mul_shares: Vec<F> = shares.iter().map(|x| (*x) * (*x)).collect();
+        let red_shares = network.simulate_network_round((mul_shares, pp), |net, (mul_shares, pp)| async move {
+            let idx = net.party_id() as usize;
+            let mul_share = mul_shares[idx].clone();
+
+            deg_red(vec![mul_share], &pp, &net, MultiplexedStreamID::One).await.unwrap()
+        }).await;
+        
+        let computed = transpose(red_shares)
+            .into_iter()
+            .flat_map(|x| pp.unpack(x))
+            .collect::<Vec<_>>();
+
+        assert_eq!(computed, expected);
+    }
 }

--- a/dist-primitives/src/utils/deg_red.rs
+++ b/dist-primitives/src/utils/deg_red.rs
@@ -25,11 +25,9 @@ pub async fn deg_red<
         received_shares.map(|x_shares: Vec<Vec<T>>| {
             let mut x_shares = transpose(x_shares);
 
-            for i in 0..x_shares.len() {
-                let xi: Vec<T> = pp.unpack2(x_shares[i].clone());
-                x_shares[i] = pp.pack(xi, &mut rand::thread_rng());
-                // pp.unpack2_in_place(px_share);
-                // pp.pack_from_public_in_place(px_share);
+            for x_share in &mut x_shares {
+                let xi: Vec<T> = pp.unpack2(x_share.clone());
+                *x_share = pp.pack(xi, &mut rand::thread_rng());
             }
             transpose(x_shares)
         });

--- a/dist-primitives/src/utils/deg_red.rs
+++ b/dist-primitives/src/utils/deg_red.rs
@@ -10,7 +10,11 @@ use crate::channel::MpcSerNet;
 use super::pack::transpose;
 
 /// Reduces the degree of a poylnomial with the help of king
-pub async fn deg_red<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize + UniformRand, Net: MpcSerNet>(
+pub async fn deg_red<
+    F: FftField,
+    T: DomainCoeff<F> + CanonicalSerialize + CanonicalDeserialize + UniformRand,
+    Net: MpcSerNet,
+>(
     x_share: Vec<T>,
     pp: &PackedSharingParams<F>,
     net: &Net,
@@ -20,7 +24,7 @@ pub async fn deg_red<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + Canon
     let king_answer: Option<Vec<Vec<T>>> =
         received_shares.map(|x_shares: Vec<Vec<T>>| {
             let mut x_shares = transpose(x_shares);
-            
+
             for i in 0..x_shares.len() {
                 let xi: Vec<T> = pp.unpack2(x_shares[i].clone());
                 x_shares[i] = pp.pack(xi, &mut rand::thread_rng());
@@ -34,12 +38,12 @@ pub async fn deg_red<F: FftField, T: DomainCoeff<F> + CanonicalSerialize + Canon
 }
 
 #[cfg(test)]
-mod tests{
-    use mpc_net::{LocalTestNet, MultiplexedStreamID};
-    use secret_sharing::pss::PackedSharingParams;
+mod tests {
     use ark_bls12_377::Fr as F;
     use ark_std::UniformRand;
     use mpc_net::MpcNet;
+    use mpc_net::{LocalTestNet, MultiplexedStreamID};
+    use secret_sharing::pss::PackedSharingParams;
 
     use crate::utils::{deg_red::deg_red, pack::transpose};
 
@@ -49,20 +53,32 @@ mod tests{
         let pp = PackedSharingParams::<F>::new(L);
         let rng = &mut ark_std::test_rng();
         let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
-        
+
         let secrets: [F; L] = UniformRand::rand(rng);
         let secrets = secrets.to_vec();
         let expected: Vec<F> = secrets.iter().map(|x| (*x) * (*x)).collect();
 
         let shares = pp.pack(secrets, rng);
         let mul_shares: Vec<F> = shares.iter().map(|x| (*x) * (*x)).collect();
-        let red_shares = network.simulate_network_round((mul_shares, pp), |net, (mul_shares, pp)| async move {
-            let idx = net.party_id() as usize;
-            let mul_share = mul_shares[idx].clone();
+        let red_shares = network
+            .simulate_network_round(
+                (mul_shares, pp),
+                |net, (mul_shares, pp)| async move {
+                    let idx = net.party_id() as usize;
+                    let mul_share = mul_shares[idx].clone();
 
-            deg_red(vec![mul_share], &pp, &net, MultiplexedStreamID::One).await.unwrap()
-        }).await;
-        
+                    deg_red(
+                        vec![mul_share],
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::One,
+                    )
+                    .await
+                    .unwrap()
+                },
+            )
+            .await;
+
         let computed = transpose(red_shares)
             .into_iter()
             .flat_map(|x| pp.unpack(x))

--- a/dist-primitives/src/utils/pack.rs
+++ b/dist-primitives/src/utils/pack.rs
@@ -1,5 +1,6 @@
 use ark_ff::FftField;
 use secret_sharing::pss::PackedSharingParams;
+use rand::thread_rng;
 
 pub fn pack_vec<F: FftField>(
     secrets: &Vec<F>,
@@ -7,14 +8,16 @@ pub fn pack_vec<F: FftField>(
 ) -> Vec<Vec<F>> {
     debug_assert_eq!(secrets.len() % pp.l, 0, "Mismatch of size in pack_vec");
 
+    let rng = &mut thread_rng();
     // pack shares
     let shares = secrets
         .chunks(pp.l)
-        .map(|x| pp.pack_from_public(x.to_vec()))
+        .map(|x| pp.pack(x.to_vec(), rng))
         .collect::<Vec<_>>();
 
     shares
 }
+
 pub fn transpose<T: Clone>(matrix: Vec<Vec<T>>) -> Vec<Vec<T>> {
     assert!(!matrix.is_empty());
     let cols = matrix[0].len();

--- a/dist-primitives/src/utils/pack.rs
+++ b/dist-primitives/src/utils/pack.rs
@@ -1,6 +1,6 @@
 use ark_ff::FftField;
-use secret_sharing::pss::PackedSharingParams;
 use rand::thread_rng;
+use secret_sharing::pss::PackedSharingParams;
 
 pub fn pack_vec<F: FftField>(
     secrets: &Vec<F>,

--- a/groth16/examples/sha256.rs
+++ b/groth16/examples/sha256.rs
@@ -99,6 +99,7 @@ fn pack_from_witness<E: Pairing>(
     pp: &PackedSharingParams<E::ScalarField>,
     full_assignment: Vec<E::ScalarField>,
 ) -> Vec<Vec<E::ScalarField>> {
+    let rng = &mut ark_std::test_rng();
     let packed_assignments = cfg_chunks!(full_assignment, pp.l)
         .map(|chunk| {
             let secrets = if chunk.len() < pp.l {
@@ -108,7 +109,7 @@ fn pack_from_witness<E: Pairing>(
             } else {
                 chunk.to_vec()
             };
-            pp.pack_from_public(secrets)
+            pp.pack(secrets, rng)
         })
         .collect::<Vec<_>>();
 
@@ -166,11 +167,10 @@ async fn main() {
 
     let pp = PackedSharingParams::new(2);
     let qap_shares = qap.pss(&pp);
-    let pp_g1 = PackedSharingParams::new(pp.l);
-    let pp_g2 = PackedSharingParams::new(pp.l);
+    let pp = PackedSharingParams::new(pp.l);
     let crs_shares =
         PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(
-            &pk, pp_g1, pp_g2,
+            &pk, pp,
         );
     let crs_shares = Arc::new(crs_shares);
     let qap_shares = Arc::new(qap_shares);

--- a/groth16/examples/sha256.rs
+++ b/groth16/examples/sha256.rs
@@ -39,7 +39,7 @@ where
     E: Pairing,
     Net: MpcNet,
 {
-    let h_share = ext_wit::h(qap_share, pp, &net).await.unwrap();
+    let h_share = ext_wit::circom_h(qap_share, pp, &net).await.unwrap();
     let msm_section = start_timer!(|| "MSM operations");
     // Compute msm while dropping the base vectors as they are not used again
     let compute_a = start_timer!(|| "Compute A");

--- a/groth16/examples/sha256.rs
+++ b/groth16/examples/sha256.rs
@@ -169,9 +169,7 @@ async fn main() {
     let qap_shares = qap.pss(&pp);
     let pp = PackedSharingParams::new(pp.l);
     let crs_shares =
-        PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(
-            &pk, pp,
-        );
+        PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(&pk, pp);
     let crs_shares = Arc::new(crs_shares);
     let qap_shares = Arc::new(qap_shares);
     let aux_assignment = &full_assignment[num_inputs..];

--- a/groth16/src/ext_wit.rs
+++ b/groth16/src/ext_wit.rs
@@ -1,10 +1,8 @@
 use ark_ff::{FftField, PrimeField};
 use ark_poly::EvaluationDomain;
-use ark_relations::r1cs::SynthesisError;
 use ark_std::cfg_into_iter;
 use dist_primitives::channel::MpcSerNet;
 use dist_primitives::dfft::{d_fft, d_ifft};
-use dist_primitives::utils::pack::{pack_vec, transpose};
 use mpc_net::{MpcNetError, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
 
@@ -27,84 +25,50 @@ pub async fn h<
     const CHANNEL2: MultiplexedStreamID = MultiplexedStreamID::Two;
 
     let domain = qap_share.domain;
+    let coset_dom = domain.get_coset(F::GENERATOR).unwrap();
     let m = domain.size();
-    let domain2 =
-        D::new(2 * m).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
 
     let a_coeff_fut =
-        d_ifft(qap_share.a, true, &domain, pp, net, CHANNEL0);
+        d_ifft(qap_share.a, true, &domain, coset_dom.coset_offset(), pp, net, CHANNEL0);
     let b_coeff_fut =
-        d_ifft(qap_share.b, true, &domain, pp, net, CHANNEL1);
+        d_ifft(qap_share.b, true, &domain, coset_dom.coset_offset(), pp, net, CHANNEL1);
     let c_coeff_fut =
-        d_ifft(qap_share.c, true, &domain, pp, net, CHANNEL2);
+        d_ifft(qap_share.c, true, &domain, coset_dom.coset_offset(), pp, net, CHANNEL2);
 
     let (a_coeff, b_coeff, c_coeff) =
         tokio::try_join!(a_coeff_fut, b_coeff_fut, c_coeff_fut)?;
 
-    /*
-    let p_eval_fut =
-        d_fft(p_coeff, false, 1, false, &domain2, pp, net, CHANNEL0);
-    let q_eval_fut =
-        d_fft(q_coeff, false, 1, false, &domain2, pp, net, CHANNEL1);
-    let w_eval_fut =
-        d_fft(w_coeff, false, 1, false, &domain2, pp, net, CHANNEL2);
+    let a_eval_fut =
+        d_fft(a_coeff, true, &domain, pp, net, CHANNEL0);
+    let b_eval_fut =
+        d_fft(b_coeff, true, &domain, pp, net, CHANNEL1);
+    let c_eval_fut =
+        d_fft(c_coeff, true, &domain, pp, net, CHANNEL2);
 
-    let (p_eval, q_eval, w_eval) =
-        tokio::try_join!(p_eval_fut, q_eval_fut, w_eval_fut)?;
+    
+    // evaluations of a, b, c over the coset
+    let (a_eval, b_eval, c_eval) =
+        tokio::try_join!(a_eval_fut, b_eval_fut, c_eval_fut)?;
 
-    let received_p_shares_fut = net.send_to_king(&p_eval, CHANNEL0);
-    let received_q_shares_fut = net.send_to_king(&q_eval, CHANNEL1);
-    let received_w_shares_fut = net.send_to_king(&w_eval, CHANNEL2);
+    // compute (a.b-c)/z
+    let vanishing_polynomial_over_coset = domain
+            .evaluate_vanishing_polynomial(F::GENERATOR)
+            .inverse()
+            .unwrap();
 
-    // Send the shares to the king to do the final computation
-    let (received_p_shares, received_q_shares, received_w_shares) = tokio::try_join!(
-        received_p_shares_fut,
-        received_q_shares_fut,
-        received_w_shares_fut
-    )?;
-    // King receives shares of p, q, w
-    let h_share = if let (Some(p_shares), Some(q_shares), Some(w_shares)) =
-        (received_p_shares, received_q_shares, received_w_shares)
-    {
-        let unpack_shares = |v| {
-            let mut s1 = cfg_into_iter!(transpose(v))
-                .flat_map(|x| pp.unpack(x))
-                .collect::<Vec<_>>();
-            // swap each ith element with l*i+t element
-            // TODO: Guru should help explaining this
-            for i in 0..m {
-                s1.swap(i, i * pp.l + pp.t);
-            }
-            s1
-        };
-        let mut p_eval = unpack_shares(p_shares);
-        let mut q_eval = unpack_shares(q_shares);
-        let mut w_eval = unpack_shares(w_shares);
+    let h_eval = cfg_into_iter!(a_eval)
+        .zip(b_eval)
+        .zip(c_eval)
+        .map(|((a, b), c)| (a*b - c)*vanishing_polynomial_over_coset)
+        .collect::<Vec<_>>();
 
-        println!("p_eval:{}", p_eval.len());
-        println!("q_eval:{}", q_eval.len());
-        println!("w_eval:{}", w_eval.len());
+    // run coset_ifft to get back coefficients of h
+    let h_coeff_fut =
+        d_ifft(h_eval, false, &domain, coset_dom.coset_offset_inv(), pp, net, CHANNEL0);
+    
+    let h_coeff = tokio::try_join!(h_coeff_fut)?.0;
 
-        p_eval.truncate(m);
-        q_eval.truncate(m);
-        w_eval.truncate(m);
-
-        // King do the final step of multiplication.
-        let h = cfg_into_iter!(p_eval)
-            .zip(q_eval)
-            .zip(w_eval)
-            .map(|((p, q), w)| p.mul(q).sub(w))
-            .collect::<Vec<_>>();
-        // pack and send to parties
-        let h_shares = transpose(pack_vec(&h, pp));
-        net.recv_from_king(Some(h_shares), CHANNEL0).await?
-    } else {
-        net.recv_from_king(None, CHANNEL0).await?
-    };
-
-    Ok(h_share)
-    */
-    unimplemented!()
+    Ok(h_coeff)
 }
 
 #[cfg(test)]
@@ -112,18 +76,102 @@ mod tests {
     use ark_bn254::Bn254;
     use ark_bn254::Fr as Bn254Fr;
     use ark_circom::{CircomBuilder, CircomConfig, CircomReduction};
+    use ark_groth16::r1cs_to_qap::LibsnarkReduction;
     use ark_groth16::r1cs_to_qap::R1CSToQAP;
     use ark_poly::Radix2EvaluationDomain;
     use ark_relations::r1cs::ConstraintSynthesizer;
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::cfg_iter;
+    use ark_std::cfg_iter_mut;
+    use dist_primitives::utils::pack::transpose;
     use mpc_net::LocalTestNet;
+
+    use crate::qap::QAP;
 
     use super::*;
     use mpc_net::MpcNet;
 
+    fn ark_h<F: PrimeField>(
+        mut a: Vec<F>,
+        mut b: Vec<F>,
+        mut c: Vec<F>,
+        domain: &Radix2EvaluationDomain<F>,
+    ) -> Vec<F> {
+        
+        domain.ifft_in_place(&mut a);
+        domain.ifft_in_place(&mut b);
+        domain.ifft_in_place(&mut c);
+
+        let coset_domain = domain.get_coset(F::GENERATOR).unwrap();
+
+        coset_domain.fft_in_place(&mut a);
+        coset_domain.fft_in_place(&mut b);
+        coset_domain.fft_in_place(&mut c);
+
+        let mut ab = domain.mul_polynomials_in_evaluation_domain(&a, &b);
+        drop(a);
+        drop(b);
+
+        let vanishing_polynomial_over_coset = domain
+            .evaluate_vanishing_polynomial(F::GENERATOR)
+            .inverse()
+            .unwrap();
+
+        cfg_iter_mut!(ab).zip(c).for_each(|(ab_i, c_i)| {
+            *ab_i -= &c_i;
+            *ab_i *= &vanishing_polynomial_over_coset;
+        });
+
+        coset_domain.ifft_in_place(&mut ab);
+
+        ab
+    }
+
     #[tokio::test]
-    async fn ext_witness_works() {
+    async fn dummy_ext_witness() {
+        let m = 32usize;
+
+        let a = (0..m).map(|x| Bn254Fr::from(x as u64)).collect::<Vec<_>>();
+        let b = (0..m).map(|x| Bn254Fr::from(x as u64)).collect::<Vec<_>>();
+        let c = a.iter().zip(b.iter()).map(|(a, b)| a * b).collect::<Vec<_>>();
+
+        let domain = Radix2EvaluationDomain::<Bn254Fr>::new(m).unwrap();
+
+        let expected_h = ark_h(a.clone(), b.clone(), c.clone(), &domain);
+
+        let pp = PackedSharingParams::<Bn254Fr>::new(2);
+        let qap = QAP::<Bn254Fr, Radix2EvaluationDomain<_>> {
+            num_inputs: 0,
+            num_constraints: 0,
+            a,
+            b,
+            c,
+            domain,
+        };
+        let qap_shares = qap.pss(&pp);
+        let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
+
+        let result = network
+            .simulate_network_round(
+                (pp.clone(), qap_shares),
+                |net, (pp, qap_shares)| async move {
+                    h(qap_shares[net.party_id() as usize].clone(), &pp, &net)
+                        .await
+                        .unwrap()
+                },
+            )
+            .await;
+
+        let computed_h = transpose(result)
+            .into_iter()
+            .flat_map(|x| pp.unpack2(x))
+            .collect::<Vec<_>>();
+
+        assert_eq!(expected_h, computed_h);
+    }
+
+    #[tokio::test]
+    async fn ext_witness_ark() {
         let cfg = CircomConfig::<Bn254>::new(
             "../fixtures/sha256/sha256_js/sha256.wasm",
             "../fixtures/sha256/sha256.r1cs",
@@ -141,14 +189,29 @@ mod tests {
 
         let num_inputs = matrices.num_instance_variables;
         let num_constraints = matrices.num_constraints;
-        let expected_h =
-            CircomReduction::witness_map_from_matrices::<
-                Bn254Fr,
-                Radix2EvaluationDomain<_>,
-            >(
-                &matrices, num_inputs, num_constraints, &full_assignment
-            )
-            .unwrap();
+        // let expected_h =
+        //     CircomReduction::witness_map_from_matrices::<
+        //         Bn254Fr,
+        //         Radix2EvaluationDomain<_>,
+        //     >(
+        //         &matrices, num_inputs, num_constraints, &full_assignment
+        //     )
+        //     .unwrap();
+        let ark_h = LibsnarkReduction::witness_map_from_matrices::<
+        Bn254Fr,
+        Radix2EvaluationDomain<_>,
+        >(
+            &matrices,
+            num_inputs,
+            num_constraints,
+            &full_assignment,
+        ).unwrap();
+
+        // // collect alternate entrries from expected_h
+        // let should_be_h = expected_h.iter().step_by(2).skip(1).map(|x| *x).collect::<Vec<_>>();
+        // assert_eq!(should_be_h, ark_h);
+
+
         let qap = crate::qap::qap::<Bn254Fr, Radix2EvaluationDomain<_>>(
             &matrices,
             &full_assignment,
@@ -170,29 +233,31 @@ mod tests {
 
         let computed_h = transpose(result)
             .into_iter()
-            .flat_map(|x| pp.unpack(x))
+            .flat_map(|x| pp.unpack2(x))
             .collect::<Vec<_>>();
 
-        eprintln!("```");
-        for i in 0..expected_h.len() {
-            eprintln!("ACTL: {}", expected_h[i]);
-            eprintln!("COMP: {}", computed_h[i]);
-            if expected_h[i] == computed_h[i] {
-                eprintln!("..{i}th element Matched ✅");
-            } else {
-                eprintln!("..{i}th element Mismatched ❌");
-                // search for the element in actual_x_coeff
-                let found =
-                    cfg_iter!(computed_h).position(|&x| x == expected_h[i]);
-                match found {
-                    Some(i) => eprintln!(
-                        "....However, it has been found at index: {i} ⚠️"
-                    ),
-                    None => eprintln!("....and Not found at all 🤔"),
-                }
-            }
-            assert_eq!(computed_h[i], expected_h[i]);
-        }
-        eprintln!("```");
+        assert_eq!(ark_h, computed_h);
+
+        // eprintln!("```");
+        // for i in 0..expected_h.len() {
+        //     eprintln!("ACTL: {}", expected_h[i]);
+        //     eprintln!("COMP: {}", computed_h[i]);
+        //     if expected_h[i] == computed_h[i] {
+        //         eprintln!("..{i}th element Matched ✅");
+        //     } else {
+        //         eprintln!("..{i}th element Mismatched ❌");
+        //         // search for the element in actual_x_coeff
+        //         let found =
+        //             cfg_iter!(computed_h).position(|&x| x == expected_h[i]);
+        //         match found {
+        //             Some(i) => eprintln!(
+        //                 "....However, it has been found at index: {i} ⚠️"
+        //             ),
+        //             None => eprintln!("....and Not found at all 🤔"),
+        //         }
+        //     }
+        //     assert_eq!(computed_h[i], expected_h[i]);
+        // }
+        // eprintln!("```");
     }
 }

--- a/groth16/src/ext_wit.rs
+++ b/groth16/src/ext_wit.rs
@@ -141,9 +141,7 @@ pub async fn circom_h<
         .map(|((a, b), c)| (a * b - c))
         .collect::<Vec<_>>();
 
-    let h_eval_red_fut = deg_red(h_eval, pp, net, CHANNEL0);
-
-    let h_eval_red = tokio::try_join!(h_eval_red_fut)?.0;
+    let h_eval_red = deg_red(h_eval, pp, net, CHANNEL0).await?;
     Ok(h_eval_red)
 }
 

--- a/groth16/src/ext_wit.rs
+++ b/groth16/src/ext_wit.rs
@@ -31,16 +31,17 @@ pub async fn h<
     let domain2 =
         D::new(2 * m).ok_or(SynthesisError::PolynomialDegreeTooLarge)?;
 
-    let p_coeff_fut =
-        d_ifft(qap_share.a, true, 2, false, &domain, pp, net, CHANNEL0);
-    let q_coeff_fut =
-        d_ifft(qap_share.b, true, 2, false, &domain, pp, net, CHANNEL1);
-    let w_coeff_fut =
-        d_ifft(qap_share.c, true, 2, false, &domain, pp, net, CHANNEL2);
+    let a_coeff_fut =
+        d_ifft(qap_share.a, true, &domain, pp, net, CHANNEL0);
+    let b_coeff_fut =
+        d_ifft(qap_share.b, true, &domain, pp, net, CHANNEL1);
+    let c_coeff_fut =
+        d_ifft(qap_share.c, true, &domain, pp, net, CHANNEL2);
 
-    let (p_coeff, q_coeff, w_coeff) =
-        tokio::try_join!(p_coeff_fut, q_coeff_fut, w_coeff_fut)?;
+    let (a_coeff, b_coeff, c_coeff) =
+        tokio::try_join!(a_coeff_fut, b_coeff_fut, c_coeff_fut)?;
 
+    /*
     let p_eval_fut =
         d_fft(p_coeff, false, 1, false, &domain2, pp, net, CHANNEL0);
     let q_eval_fut =
@@ -80,6 +81,10 @@ pub async fn h<
         let mut q_eval = unpack_shares(q_shares);
         let mut w_eval = unpack_shares(w_shares);
 
+        println!("p_eval:{}", p_eval.len());
+        println!("q_eval:{}", q_eval.len());
+        println!("w_eval:{}", w_eval.len());
+
         p_eval.truncate(m);
         q_eval.truncate(m);
         w_eval.truncate(m);
@@ -98,6 +103,8 @@ pub async fn h<
     };
 
     Ok(h_share)
+    */
+    unimplemented!()
 }
 
 #[cfg(test)]

--- a/groth16/src/ext_wit.rs
+++ b/groth16/src/ext_wit.rs
@@ -88,7 +88,8 @@ pub async fn libsnark_h<
         pp,
         net,
         CHANNEL0,
-    ).await?;
+    )
+    .await?;
 
     Ok(h_coeff)
 }

--- a/groth16/src/ext_wit.rs
+++ b/groth16/src/ext_wit.rs
@@ -1,17 +1,18 @@
 use ark_ff::{FftField, PrimeField};
-use ark_poly::EvaluationDomain;
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_std::cfg_into_iter;
 use dist_primitives::channel::MpcSerNet;
 use dist_primitives::dfft::{d_fft, d_ifft};
 use mpc_net::{MpcNetError, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
+use dist_primitives::utils::deg_red::deg_red;
 
 use crate::qap::PackedQAPShare;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-pub async fn h<
+pub async fn libsnark_h<
     F: FftField + PrimeField,
     D: EvaluationDomain<F>,
     Net: MpcSerNet,
@@ -26,49 +27,145 @@ pub async fn h<
 
     let domain = qap_share.domain;
     let coset_dom = domain.get_coset(F::GENERATOR).unwrap();
-    let m = domain.size();
 
-    let a_coeff_fut =
-        d_ifft(qap_share.a, true, &domain, coset_dom.coset_offset(), pp, net, CHANNEL0);
-    let b_coeff_fut =
-        d_ifft(qap_share.b, true, &domain, coset_dom.coset_offset(), pp, net, CHANNEL1);
-    let c_coeff_fut =
-        d_ifft(qap_share.c, true, &domain, coset_dom.coset_offset(), pp, net, CHANNEL2);
+    let a_coeff_fut = d_ifft(
+        qap_share.a,
+        true,
+        &domain,
+        coset_dom.coset_offset(),
+        pp,
+        net,
+        CHANNEL0,
+    );
+    let b_coeff_fut = d_ifft(
+        qap_share.b,
+        true,
+        &domain,
+        coset_dom.coset_offset(),
+        pp,
+        net,
+        CHANNEL1,
+    );
+    let c_coeff_fut = d_ifft(
+        qap_share.c,
+        true,
+        &domain,
+        coset_dom.coset_offset(),
+        pp,
+        net,
+        CHANNEL2,
+    );
 
     let (a_coeff, b_coeff, c_coeff) =
         tokio::try_join!(a_coeff_fut, b_coeff_fut, c_coeff_fut)?;
 
-    let a_eval_fut =
-        d_fft(a_coeff, true, &domain, pp, net, CHANNEL0);
-    let b_eval_fut =
-        d_fft(b_coeff, true, &domain, pp, net, CHANNEL1);
-    let c_eval_fut =
-        d_fft(c_coeff, true, &domain, pp, net, CHANNEL2);
+    let a_eval_fut = d_fft(a_coeff, true, &domain, pp, net, CHANNEL0);
+    let b_eval_fut = d_fft(b_coeff, true, &domain, pp, net, CHANNEL1);
+    let c_eval_fut = d_fft(c_coeff, true, &domain, pp, net, CHANNEL2);
 
-    
     // evaluations of a, b, c over the coset
     let (a_eval, b_eval, c_eval) =
         tokio::try_join!(a_eval_fut, b_eval_fut, c_eval_fut)?;
 
-    // compute (a.b-c)/z
+    // compute (ab-c)/z
     let vanishing_polynomial_over_coset = domain
-            .evaluate_vanishing_polynomial(F::GENERATOR)
-            .inverse()
-            .unwrap();
+        .evaluate_vanishing_polynomial(F::GENERATOR)
+        .inverse()
+        .unwrap();
 
     let h_eval = cfg_into_iter!(a_eval)
         .zip(b_eval)
         .zip(c_eval)
-        .map(|((a, b), c)| (a*b - c)*vanishing_polynomial_over_coset)
+        .map(|((a, b), c)| (a * b - c) * vanishing_polynomial_over_coset)
         .collect::<Vec<_>>();
 
     // run coset_ifft to get back coefficients of h
-    let h_coeff_fut =
-        d_ifft(h_eval, false, &domain, coset_dom.coset_offset_inv(), pp, net, CHANNEL0);
-    
+    let h_coeff_fut = d_ifft(
+        h_eval,
+        false,
+        &domain,
+        coset_dom.coset_offset_inv(),
+        pp,
+        net,
+        CHANNEL0,
+    );
+
     let h_coeff = tokio::try_join!(h_coeff_fut)?.0;
 
     Ok(h_coeff)
+}
+
+pub async fn circom_h<
+    F: FftField + PrimeField,
+    D: EvaluationDomain<F>,
+    Net: MpcSerNet,
+>(
+    qap_share: PackedQAPShare<F, D>,
+    pp: &PackedSharingParams<F>,
+    net: &Net,
+) -> Result<Vec<F>, MpcNetError> {
+    const CHANNEL0: MultiplexedStreamID = MultiplexedStreamID::Zero;
+    const CHANNEL1: MultiplexedStreamID = MultiplexedStreamID::One;
+    const CHANNEL2: MultiplexedStreamID = MultiplexedStreamID::Two;
+
+    let domain = qap_share.domain;
+    let root_of_unity = {
+        let domain_size_double = 2 * domain.size();
+        let domain_double =
+        Radix2EvaluationDomain::<F>::new(domain_size_double).unwrap();
+        domain_double.element(1)
+    };
+    
+    let a_coeff_fut = d_ifft(
+        qap_share.a,
+        true,
+        &domain,
+        root_of_unity,
+        pp,
+        net,
+        CHANNEL0,
+    );
+    let b_coeff_fut = d_ifft(
+        qap_share.b,
+        true,
+        &domain,
+        root_of_unity,
+        pp,
+        net,
+        CHANNEL1,
+    );
+    let c_coeff_fut = d_ifft(
+        qap_share.c,
+        true,
+        &domain,
+        root_of_unity,
+        pp,
+        net,
+        CHANNEL2,
+    );
+
+    let (a_coeff, b_coeff, c_coeff) =
+        tokio::try_join!(a_coeff_fut, b_coeff_fut, c_coeff_fut)?;
+    
+    let a_eval_fut = d_fft(a_coeff, false, &domain, pp, net, CHANNEL0);
+    let b_eval_fut = d_fft(b_coeff, false, &domain, pp, net, CHANNEL1);
+    let c_eval_fut = d_fft(c_coeff, false, &domain, pp, net, CHANNEL2);
+
+    // evaluations of a, b, c over the coset
+    let (a_eval, b_eval, c_eval) =
+        tokio::try_join!(a_eval_fut, b_eval_fut, c_eval_fut)?;
+
+    // compute (ab-c)
+    let h_eval = cfg_into_iter!(a_eval)
+        .zip(b_eval)
+        .zip(c_eval)
+        .map(|((a, b), c)| (a * b - c))
+        .collect::<Vec<_>>();
+
+    let h_eval_red_fut = deg_red(h_eval, pp, net, CHANNEL0);
+
+    let h_eval_red = tokio::try_join!(h_eval_red_fut)?.0;
+    Ok(h_eval_red)
 }
 
 #[cfg(test)]
@@ -76,12 +173,10 @@ mod tests {
     use ark_bn254::Bn254;
     use ark_bn254::Fr as Bn254Fr;
     use ark_circom::{CircomBuilder, CircomConfig, CircomReduction};
-    use ark_groth16::r1cs_to_qap::LibsnarkReduction;
     use ark_groth16::r1cs_to_qap::R1CSToQAP;
     use ark_poly::Radix2EvaluationDomain;
     use ark_relations::r1cs::ConstraintSynthesizer;
     use ark_relations::r1cs::ConstraintSystem;
-    use ark_std::cfg_iter;
     use ark_std::cfg_iter_mut;
     use dist_primitives::utils::pack::transpose;
     use mpc_net::LocalTestNet;
@@ -91,13 +186,12 @@ mod tests {
     use super::*;
     use mpc_net::MpcNet;
 
-    fn ark_h<F: PrimeField>(
+    fn libsnark_ref<F: PrimeField>(
         mut a: Vec<F>,
         mut b: Vec<F>,
         mut c: Vec<F>,
         domain: &Radix2EvaluationDomain<F>,
     ) -> Vec<F> {
-        
         domain.ifft_in_place(&mut a);
         domain.ifft_in_place(&mut b);
         domain.ifft_in_place(&mut c);
@@ -127,17 +221,57 @@ mod tests {
         ab
     }
 
+    fn circom_ref<F: PrimeField>(
+        mut a: Vec<F>,
+        mut b: Vec<F>,
+        mut c: Vec<F>,
+        domain: &Radix2EvaluationDomain<F>,
+    ) -> Vec<F> {
+        domain.ifft_in_place(&mut a);
+        domain.ifft_in_place(&mut b);
+
+        let root_of_unity = {
+            let domain_size_double = 2 * domain.size();
+            let domain_double =
+            Radix2EvaluationDomain::<F>::new(domain_size_double).unwrap();
+            domain_double.element(1)
+        };
+        Radix2EvaluationDomain::<F>::distribute_powers_and_mul_by_const(&mut a, root_of_unity, F::one());
+        Radix2EvaluationDomain::<F>::distribute_powers_and_mul_by_const(&mut b, root_of_unity, F::one());
+
+        domain.fft_in_place(&mut a);
+        domain.fft_in_place(&mut b);
+
+        let mut ab = domain.mul_polynomials_in_evaluation_domain(&a, &b);
+        drop(a);
+        drop(b);
+
+        domain.ifft_in_place(&mut c);
+        Radix2EvaluationDomain::<F>::distribute_powers_and_mul_by_const(&mut c, root_of_unity, F::one());
+        domain.fft_in_place(&mut c);
+
+        cfg_iter_mut!(ab)
+            .zip(c)
+            .for_each(|(ab_i, c_i)| *ab_i -= &c_i);
+
+        ab
+    }
+
     #[tokio::test]
-    async fn dummy_ext_witness() {
+    async fn libsnark_dummy_ext_witness() {
         let m = 32usize;
 
         let a = (0..m).map(|x| Bn254Fr::from(x as u64)).collect::<Vec<_>>();
         let b = (0..m).map(|x| Bn254Fr::from(x as u64)).collect::<Vec<_>>();
-        let c = a.iter().zip(b.iter()).map(|(a, b)| a * b).collect::<Vec<_>>();
+        let c = a
+            .iter()
+            .zip(b.iter())
+            .map(|(a, b)| a * b)
+            .collect::<Vec<_>>();
 
         let domain = Radix2EvaluationDomain::<Bn254Fr>::new(m).unwrap();
 
-        let expected_h = ark_h(a.clone(), b.clone(), c.clone(), &domain);
+        let expected_h = libsnark_ref(a.clone(), b.clone(), c.clone(), &domain);
 
         let pp = PackedSharingParams::<Bn254Fr>::new(2);
         let qap = QAP::<Bn254Fr, Radix2EvaluationDomain<_>> {
@@ -155,7 +289,7 @@ mod tests {
             .simulate_network_round(
                 (pp.clone(), qap_shares),
                 |net, (pp, qap_shares)| async move {
-                    h(qap_shares[net.party_id() as usize].clone(), &pp, &net)
+                    libsnark_h(qap_shares[net.party_id() as usize].clone(), &pp, &net)
                         .await
                         .unwrap()
                 },
@@ -171,7 +305,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ext_witness_ark() {
+    async fn circom_dummy_ext_witness() {
+        let m = 8usize;
+
+        let a = (0..m).map(|x| Bn254Fr::from(x as u64)).collect::<Vec<_>>();
+        let b = (0..m).map(|x| Bn254Fr::from(x as u64)).collect::<Vec<_>>();
+        let c = a
+            .iter()
+            .zip(b.iter())
+            .map(|(a, b)| a * b)
+            .collect::<Vec<_>>();
+
+        let domain = Radix2EvaluationDomain::<Bn254Fr>::new(m).unwrap();
+
+        let expected_h = circom_ref(a.clone(), b.clone(), c.clone(), &domain);
+
+        let pp = PackedSharingParams::<Bn254Fr>::new(2);
+        let qap = QAP::<Bn254Fr, Radix2EvaluationDomain<_>> {
+            num_inputs: 0,
+            num_constraints: 0,
+            a,
+            b,
+            c,
+            domain,
+        };
+        let qap_shares = qap.pss(&pp);
+        let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
+
+        let result = network
+            .simulate_network_round(
+                (pp.clone(), qap_shares),
+                |net, (pp, qap_shares)| async move {
+                    circom_h(qap_shares[net.party_id() as usize].clone(), &pp, &net)
+                        .await
+                        .unwrap()
+                },
+            )
+            .await;
+
+        let computed_h = transpose(result)
+            .into_iter()
+            .flat_map(|x| pp.unpack2(x))
+            .collect::<Vec<_>>();
+
+        assert_eq!(expected_h, computed_h);
+    }
+
+    #[tokio::test]
+    async fn ext_witness_circom() {
         let cfg = CircomConfig::<Bn254>::new(
             "../fixtures/sha256/sha256_js/sha256.wasm",
             "../fixtures/sha256/sha256.r1cs",
@@ -189,28 +370,14 @@ mod tests {
 
         let num_inputs = matrices.num_instance_variables;
         let num_constraints = matrices.num_constraints;
-        // let expected_h =
-        //     CircomReduction::witness_map_from_matrices::<
-        //         Bn254Fr,
-        //         Radix2EvaluationDomain<_>,
-        //     >(
-        //         &matrices, num_inputs, num_constraints, &full_assignment
-        //     )
-        //     .unwrap();
-        let ark_h = LibsnarkReduction::witness_map_from_matrices::<
-        Bn254Fr,
-        Radix2EvaluationDomain<_>,
-        >(
-            &matrices,
-            num_inputs,
-            num_constraints,
-            &full_assignment,
-        ).unwrap();
-
-        // // collect alternate entrries from expected_h
-        // let should_be_h = expected_h.iter().step_by(2).skip(1).map(|x| *x).collect::<Vec<_>>();
-        // assert_eq!(should_be_h, ark_h);
-
+        let h =
+            CircomReduction::witness_map_from_matrices::<
+                Bn254Fr,
+                Radix2EvaluationDomain<_>,
+            >(
+                &matrices, num_inputs, num_constraints, &full_assignment
+            )
+            .unwrap();
 
         let qap = crate::qap::qap::<Bn254Fr, Radix2EvaluationDomain<_>>(
             &matrices,
@@ -224,7 +391,7 @@ mod tests {
             .simulate_network_round(
                 (pp.clone(), qap_shares),
                 |net, (pp, qap_shares)| async move {
-                    h(qap_shares[net.party_id() as usize].clone(), &pp, &net)
+                    circom_h(qap_shares[net.party_id() as usize].clone(), &pp, &net)
                         .await
                         .unwrap()
                 },
@@ -233,31 +400,10 @@ mod tests {
 
         let computed_h = transpose(result)
             .into_iter()
-            .flat_map(|x| pp.unpack2(x))
+            .flat_map(|x| pp.unpack(x))
             .collect::<Vec<_>>();
-
-        assert_eq!(ark_h, computed_h);
-
-        // eprintln!("```");
-        // for i in 0..expected_h.len() {
-        //     eprintln!("ACTL: {}", expected_h[i]);
-        //     eprintln!("COMP: {}", computed_h[i]);
-        //     if expected_h[i] == computed_h[i] {
-        //         eprintln!("..{i}th element Matched ✅");
-        //     } else {
-        //         eprintln!("..{i}th element Mismatched ❌");
-        //         // search for the element in actual_x_coeff
-        //         let found =
-        //             cfg_iter!(computed_h).position(|&x| x == expected_h[i]);
-        //         match found {
-        //             Some(i) => eprintln!(
-        //                 "....However, it has been found at index: {i} ⚠️"
-        //             ),
-        //             None => eprintln!("....and Not found at all 🤔"),
-        //         }
-        //     }
-        //     assert_eq!(computed_h[i], expected_h[i]);
-        // }
-        // eprintln!("```");
+        
+        // todo: need to do degree reduction here.
+        assert_eq!(h, computed_h);
     }
 }

--- a/groth16/src/ext_wit.rs
+++ b/groth16/src/ext_wit.rs
@@ -80,7 +80,7 @@ pub async fn libsnark_h<
         .collect::<Vec<_>>();
 
     // run coset_ifft to get back coefficients of h
-    let h_coeff_fut = d_ifft(
+    let h_coeff = d_ifft(
         h_eval,
         false,
         &domain,
@@ -88,9 +88,7 @@ pub async fn libsnark_h<
         pp,
         net,
         CHANNEL0,
-    );
-
-    let h_coeff = tokio::try_join!(h_coeff_fut)?.0;
+    ).await?;
 
     Ok(h_coeff)
 }

--- a/groth16/src/proving_key.rs
+++ b/groth16/src/proving_key.rs
@@ -163,7 +163,6 @@ mod tests {
     use ark_circom::{CircomBuilder, CircomConfig, CircomReduction};
     use ark_crypto_primitives::snark::SNARK;
     use ark_groth16::Groth16;
-    use ark_std::cfg_chunks_mut;
 
     const L: usize = 2;
 

--- a/groth16/src/proving_key.rs
+++ b/groth16/src/proving_key.rs
@@ -4,7 +4,6 @@ use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_ff::{FftField, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{cfg_chunks, cfg_into_iter};
-use dist_primitives::dmsm::packexp_from_public;
 use secret_sharing::pss::PackedSharingParams;
 
 use ark_ff::UniformRand;
@@ -34,17 +33,10 @@ where
     /// Each party will hold one share per PSS chunk.
     pub fn pack_from_arkworks_proving_key(
         pk: &ark_groth16::ProvingKey<E>,
-        pp_g1: PackedSharingParams<
+        pp: PackedSharingParams<
             <<E as Pairing>::G1Affine as AffineRepr>::ScalarField,
-        >,
-        pp_g2: PackedSharingParams<
-            <<E as Pairing>::G2Affine as AffineRepr>::ScalarField,
-        >,
+        >
     ) -> Vec<Self> {
-        assert!(pp_g1.l == pp_g2.l);
-        assert!(pp_g1.n == pp_g2.n);
-        let n = pp_g1.n;
-
         let pre_packed_s = cfg_into_iter!(pk.a_query.clone())
             .skip(1)
             .map(Into::into)
@@ -64,23 +56,25 @@ where
             .map(Into::into)
             .collect::<Vec<_>>();
 
-        let packed_s = cfg_chunks!(pre_packed_s, pp_g1.l)
-            .map(|chunk| packexp_from_public::<E::G1>(chunk, &pp_g1))
+        let rng = &mut ark_std::test_rng();
+        
+        let packed_s = cfg_chunks!(pre_packed_s, pp.l)
+            .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
             .collect::<Vec<_>>();
-        let packed_u = cfg_chunks!(pre_packed_u, pp_g1.l)
-            .map(|chunk| packexp_from_public::<E::G1>(chunk, &pp_g1))
+        let packed_u = cfg_chunks!(pre_packed_u, pp.l)
+            .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
             .collect::<Vec<_>>();
-        let packed_w = cfg_chunks!(pre_packed_w, pp_g1.l)
-            .map(|chunk| packexp_from_public::<E::G1>(chunk, &pp_g1))
+        let packed_w = cfg_chunks!(pre_packed_w, pp.l)
+            .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
             .collect::<Vec<_>>();
-        let packed_h = cfg_chunks!(pre_packed_h, pp_g1.l)
-            .map(|chunk| packexp_from_public::<E::G1>(chunk, &pp_g1))
+        let packed_h = cfg_chunks!(pre_packed_h, pp.l)
+            .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
             .collect::<Vec<_>>();
-        let packed_v = cfg_chunks!(pre_packed_v, pp_g2.l)
-            .map(|chunk| packexp_from_public::<E::G2>(chunk, &pp_g2))
+        let packed_v = cfg_chunks!(pre_packed_v, pp.l)
+            .map(|chunk| pp.pack::<E::G2>(chunk.to_vec(), rng))
             .collect::<Vec<_>>();
 
-        cfg_into_iter!(0..n)
+        cfg_into_iter!(0..pp.n)
             .map(|i| {
                 let s_shares = cfg_into_iter!(0..packed_s.len())
                     .map(|j| packed_s[j][i].into())
@@ -186,11 +180,10 @@ mod tests {
                 circom, rng,
             )
             .unwrap();
-        let pp_g1 = PackedSharingParams::new(L);
-        let pp_g2 = PackedSharingParams::new(L);
+        let pp = PackedSharingParams::new(L);
         let _shares =
             PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(
-                &pk, pp_g1, pp_g2,
+                &pk, pp
             );
     }
 }

--- a/groth16/src/proving_key.rs
+++ b/groth16/src/proving_key.rs
@@ -35,7 +35,7 @@ where
         pk: &ark_groth16::ProvingKey<E>,
         pp: PackedSharingParams<
             <<E as Pairing>::G1Affine as AffineRepr>::ScalarField,
-        >
+        >,
     ) -> Vec<Self> {
         let pre_packed_s = cfg_into_iter!(pk.a_query.clone())
             .skip(1)
@@ -57,7 +57,7 @@ where
             .collect::<Vec<_>>();
 
         let rng = &mut ark_std::test_rng();
-        
+
         let packed_s = cfg_chunks!(pre_packed_s, pp.l)
             .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
             .collect::<Vec<_>>();
@@ -183,7 +183,7 @@ mod tests {
         let pp = PackedSharingParams::new(L);
         let _shares =
             PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(
-                &pk, pp
+                &pk, pp,
             );
     }
 }

--- a/groth16/src/qap.rs
+++ b/groth16/src/qap.rs
@@ -96,20 +96,20 @@ impl<F: PrimeField, D: EvaluationDomain<F> + Send> QAP<F, D> {
         let num_inputs = self.num_inputs;
         let num_constraints = self.num_constraints;
         let domain = self.domain;
-
-        let pack = |mut x: Vec<F>| {
+        let rng = &mut ark_std::test_rng();
+        let mut pack = |mut x: Vec<F>| {
             fft_in_place_rearrange(&mut x);
             let mut pevals: Vec<Vec<F>> = Vec::new();
             let m = x.len();
             for i in 0..m / pp.l {
+                let secrets = cfg_iter!(x)
+                .skip(i)
+                .step_by(m / pp.l)
+                .cloned()
+                .collect::<Vec<_>>();
                 pevals.push(
-                    cfg_iter!(x)
-                        .skip(i)
-                        .step_by(m / pp.l)
-                        .cloned()
-                        .collect::<Vec<_>>(),
+                    pp.pack(secrets, rng)
                 );
-                pp.pack_from_public_in_place(&mut pevals[i]);
             }
             pevals
         };

--- a/groth16/src/qap.rs
+++ b/groth16/src/qap.rs
@@ -103,13 +103,11 @@ impl<F: PrimeField, D: EvaluationDomain<F> + Send> QAP<F, D> {
             let m = x.len();
             for i in 0..m / pp.l {
                 let secrets = cfg_iter!(x)
-                .skip(i)
-                .step_by(m / pp.l)
-                .cloned()
-                .collect::<Vec<_>>();
-                pevals.push(
-                    pp.pack(secrets, rng)
-                );
+                    .skip(i)
+                    .step_by(m / pp.l)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                pevals.push(pp.pack(secrets, rng));
             }
             pevals
         };

--- a/secret-sharing/src/pss.rs
+++ b/secret-sharing/src/pss.rs
@@ -1,7 +1,10 @@
-use ark_poly::{domain::{EvaluationDomain, DomainCoeff}, Radix2EvaluationDomain};
+use ark_poly::{
+    domain::{DomainCoeff, EvaluationDomain},
+    Radix2EvaluationDomain,
+};
 
 use ark_ff::FftField;
-use ark_std::{UniformRand, rand::Rng};
+use ark_std::{rand::Rng, UniformRand};
 
 /// Packed Secret Sharing Parameters
 ///
@@ -63,9 +66,12 @@ impl<F: FftField> PackedSharingParams<F> {
 
     /// Deterministically packs secrets into shares
     #[allow(unused)]
-    pub fn det_pack<T: DomainCoeff<F> + UniformRand>(&self, secrets: Vec<T>) -> Vec<T> {
+    pub fn det_pack<T: DomainCoeff<F> + UniformRand>(
+        &self,
+        secrets: Vec<T>,
+    ) -> Vec<T> {
         debug_assert!(secrets.len() == self.l, "Secrets length mismatch");
-        
+
         let mut result = secrets;
 
         // Resize the secrets with t+1 zeros
@@ -82,15 +88,18 @@ impl<F: FftField> PackedSharingParams<F> {
 
     /// Packs secrets into shares
     #[allow(unused)]
-    pub fn pack<T: DomainCoeff<F> + UniformRand>(&self, secrets: Vec<T>, rng: &mut impl Rng) -> Vec<T> {
+    pub fn pack<T: DomainCoeff<F> + UniformRand>(
+        &self,
+        secrets: Vec<T>,
+        rng: &mut impl Rng,
+    ) -> Vec<T> {
         debug_assert!(secrets.len() == self.l, "Secrets length mismatch");
-        
+
         let mut result = secrets;
 
         // Resize the secrets with t+1 random points
-        let rand_points = (0..self.t + 1)
-            .map(|_| T::rand(rng))
-            .collect::<Vec<T>>();
+        let rand_points =
+            (0..self.t + 1).map(|_| T::rand(rng)).collect::<Vec<T>>();
         result.extend_from_slice(&rand_points);
 
         // interpolating on secrets domain


### PR DESCRIPTION
A major code cleanup for the `secret-sharing` crate. We no longer have separate methods for groups/fields -- they are all unified using the `DomainCoeff` trait. 

Also added randomness when secret sharing but left a deterministic packing method which uses all 0's for randomness (sometimes useful in MPC). `pack(secrets, rng)` takes as input an `rng` and uses that to generate the random values needed.

Closes #48