### PR TITLE
Use our fork of ark-circom

### DIFF
--- a/groth16/Cargo.toml
+++ b/groth16/Cargo.toml
@@ -13,7 +13,7 @@ ark-ec = {version = "0.4.0", default-features = false}
 ark-relations = { version = "0.4.0", default-features = false }
 ark-serialize = { version = "0.4.0", default-features = false, features = [ "derive" ] }
 ark-groth16 = { version = "0.4.0", default-features = false }
-ark-circom = { git = "https://github.com/arkworks-rs/circom-compat.git" }
+ark-circom = { git = "https://github.com/webb-tools/ark-circom.git" }
 
 # ARK curves
 ark-bls12-377 = {version = "0.4.0", default-features = false, features = ["curve"] }


### PR DESCRIPTION
ark-circom uses some ark crates at 0.4.1 whereas others use 0.4.2 which creates conflict issues.

I changed the version from 0.4.1 to 0.4.2 in our fork to avoid conflicts.
