### PR TITLE
Adds randomness in each of the distributed-primitives

### DIFF
--- a/dist-primitives/examples/dfft_test.rs
+++ b/dist-primitives/examples/dfft_test.rs
@@ -2,13 +2,14 @@ use ark_bls12_377::Fr;
 use ark_ff::{FftField, PrimeField};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use dist_primitives::{
-    dfft::{d_fft, fft_in_place_rearrange},
+    dfft::{d_fft, fft_in_place_rearrange, FftMask},
     utils::pack::transpose,
 };
 use mpc_net::ser_net::MpcSerNet;
 use mpc_net::{LocalTestNet as Net, MpcNet, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
 
+// TODO: this test is subsumed by those in dfft/tests.rs. Remove it.
 pub async fn d_fft_test<F: FftField + PrimeField, Net: MpcNet>(
     pp: &PackedSharingParams<F>,
     dom: &Radix2EvaluationDomain<F>,
@@ -39,9 +40,12 @@ pub async fn d_fft_test<F: FftField + PrimeField, Net: MpcNet>(
         .map(|x| x[net.party_id() as usize])
         .collect::<Vec<_>>();
 
+    // using a dummy mask as this example will eventually be removed
+    let fft_mask = FftMask::<F>::new(vec![F::zero();mbyl], vec![F::zero();mbyl]);
+
     // Rearranging x
     let peval_share =
-        d_fft(pcoeff_share, false, dom, pp, net, MultiplexedStreamID::One)
+        d_fft(pcoeff_share, &fft_mask, false, dom, pp, net, MultiplexedStreamID::One)
             .await
             .unwrap();
 

--- a/dist-primitives/examples/dfft_test.rs
+++ b/dist-primitives/examples/dfft_test.rs
@@ -41,13 +41,21 @@ pub async fn d_fft_test<F: FftField + PrimeField, Net: MpcNet>(
         .collect::<Vec<_>>();
 
     // using a dummy mask as this example will eventually be removed
-    let fft_mask = FftMask::<F>::new(vec![F::zero();mbyl], vec![F::zero();mbyl]);
+    let fft_mask =
+        FftMask::<F>::new(vec![F::zero(); mbyl], vec![F::zero(); mbyl]);
 
     // Rearranging x
-    let peval_share =
-        d_fft(pcoeff_share, &fft_mask, false, dom, pp, net, MultiplexedStreamID::One)
-            .await
-            .unwrap();
+    let peval_share = d_fft(
+        pcoeff_share,
+        &fft_mask,
+        false,
+        dom,
+        pp,
+        net,
+        MultiplexedStreamID::One,
+    )
+    .await
+    .unwrap();
 
     // Send to king who reconstructs and checks the answer
     let result = net

--- a/dist-primitives/examples/dmsm_bench.rs
+++ b/dist-primitives/examples/dmsm_bench.rs
@@ -2,7 +2,7 @@ use ark_bls12_377::Fr;
 use ark_ec::CurveGroup;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_std::{UniformRand, Zero};
-use dist_primitives::dmsm::d_msm;
+use dist_primitives::dmsm::{d_msm, MsmMask};
 use mpc_net::{LocalTestNet as Net, MpcNet, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
 
@@ -29,11 +29,11 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
     let x_share_aff: Vec<G::Affine> =
         x_share.iter().map(|s| (*s).into()).collect();
 
+    let msm_mask = MsmMask::<G>::new(G::zero(), G::zero());
     d_msm::<G, _>(
         &x_share_aff,
         &y_share,
-        G::zero(),
-        G::zero(),
+        &msm_mask,
         pp,
         net,
         MultiplexedStreamID::One,

--- a/dist-primitives/examples/dmsm_bench.rs
+++ b/dist-primitives/examples/dmsm_bench.rs
@@ -29,9 +29,17 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
     let x_share_aff: Vec<G::Affine> =
         x_share.iter().map(|s| (*s).into()).collect();
 
-    d_msm::<G, _>(&x_share_aff, &y_share, pp, net, MultiplexedStreamID::One)
-        .await
-        .unwrap();
+    d_msm::<G, _>(
+        &x_share_aff,
+        &y_share,
+        G::zero(),
+        G::zero(),
+        pp,
+        net,
+        MultiplexedStreamID::One,
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::main]

--- a/dist-primitives/examples/dmsm_test.rs
+++ b/dist-primitives/examples/dmsm_test.rs
@@ -27,8 +27,6 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
     for _ in 0..dom.size() {
         y_pub.push(G::ScalarField::rand(rng));
         x_pub.push(G::rand(rng));
-        // y_pub.push(G::ScalarField::zero());
-        // x_pub.push(G::zero());
     }
 
     let x_share: Vec<G> = x_pub
@@ -57,6 +55,7 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
     }
     let mask_values: Vec<G> = mask_values.iter().map(|x| g * x).collect();
     let out_mask = -(mask_values.iter().sum::<G>());
+    // todo: use pack here instead of det_pack
     let in_mask = pp.det_pack(mask_values)[net.party_id() as usize];
 
     let output = d_msm::<G, Net>(

--- a/dist-primitives/examples/dmsm_test.rs
+++ b/dist-primitives/examples/dmsm_test.rs
@@ -1,44 +1,24 @@
 use ark_bls12_377::Fr;
+use ark_bls12_377::G1Projective as G;
 use ark_ec::CurveGroup;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_std::UniformRand;
-use dist_primitives::dmsm::d_msm;
+use dist_primitives::dmsm::{d_msm, MsmMask};
+use dist_primitives::utils::pack::transpose;
+use mpc_net::ser_net::MpcSerNet;
 use mpc_net::{LocalTestNet as Net, MpcNet, MultiplexedStreamID};
+use rand::thread_rng;
 use secret_sharing::pss::PackedSharingParams;
 
 pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
+    x_pub: &Vec<G>,
+    y_pub: &Vec<G::ScalarField>,
+    x_share: &Vec<G>,
+    y_share: &Vec<G::ScalarField>,
+    msm_mask: &MsmMask<G>,
     pp: &PackedSharingParams<G::ScalarField>,
-    dom: &Radix2EvaluationDomain<G::ScalarField>,
     net: &Net,
 ) {
-    let mbyl: usize = dom.size() / pp.l;
-    println!(
-        "m: {}, mbyl: {}, party_id: {}",
-        dom.size(),
-        mbyl,
-        net.party_id()
-    );
-
-    let rng = &mut ark_std::test_rng();
-
-    let mut y_pub: Vec<G::ScalarField> = Vec::new();
-    let mut x_pub: Vec<G> = Vec::new();
-
-    for _ in 0..dom.size() {
-        y_pub.push(G::ScalarField::rand(rng));
-        x_pub.push(G::rand(rng));
-    }
-
-    let x_share: Vec<G> = x_pub
-        .chunks(pp.l)
-        .map(|s| pp.pack(s.to_vec(), rng)[net.party_id() as usize])
-        .collect();
-
-    let y_share: Vec<G::ScalarField> = y_pub
-        .chunks(pp.l)
-        .map(|s| pp.pack(s.to_vec(), rng)[net.party_id() as usize])
-        .collect();
-
     let x_pub_aff: Vec<G::Affine> = x_pub.iter().map(|s| (*s).into()).collect();
     let x_share_aff: Vec<G::Affine> =
         x_share.iter().map(|s| (*s).into()).collect();
@@ -47,22 +27,11 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
     let should_be_output =
         G::msm(x_pub_aff.as_slice(), y_pub.as_slice()).unwrap();
 
-    // compute masks
-    let g = G::generator();
-    let mut mask_values = Vec::new();
-    for _ in 0..pp.l {
-        mask_values.push(G::ScalarField::rand(rng));
-    }
-    let mask_values: Vec<G> = mask_values.iter().map(|x| g * x).collect();
-    let out_mask = -(mask_values.iter().sum::<G>());
-    // todo: use pack here instead of det_pack
-    let in_mask = pp.det_pack(mask_values)[net.party_id() as usize];
-
+    // fix the check here. output should actually be shares
     let output = d_msm::<G, Net>(
         &x_share_aff,
         &y_share,
-        in_mask,
-        out_mask,
+        &msm_mask,
         pp,
         net,
         MultiplexedStreamID::One,
@@ -70,22 +39,55 @@ pub async fn d_msm_test<G: CurveGroup, Net: MpcNet>(
     .await
     .unwrap();
 
-    if net.is_king() {
-        assert_eq!(should_be_output, output);
-    }
+    net.client_send_or_king_receive_serialized(
+        &output,
+        MultiplexedStreamID::One,
+        pp.t,
+    )
+    .await
+    .unwrap()
+    .map(|rs| {
+        let result = pp.unpack_missing_shares(&rs.shares, &rs.parties);
+        assert_eq!(should_be_output, result[0]);
+    });
 }
 
 #[tokio::main]
 async fn main() {
     env_logger::builder().format_timestamp(None).init();
-
     let network = Net::new_local_testnet(8).await.unwrap();
 
+    let pp = PackedSharingParams::<Fr>::new(2);
+    let dom = Radix2EvaluationDomain::<Fr>::new(1 << 8).unwrap();
+
+    let rng = &mut thread_rng();
+
+    let mut y_pub: Vec<Fr> = Vec::new();
+    let mut x_pub: Vec<G> = Vec::new();
+
+    for _ in 0..dom.size() {
+        y_pub.push(Fr::rand(rng));
+        x_pub.push(G::rand(rng));
+    }
+
+    let x_shares: Vec<Vec<G>> = x_pub
+        .chunks(pp.l)
+        .map(|s| pp.pack(s.to_vec(), rng))
+        .collect();
+    let x_shares = transpose(x_shares);
+
+    let y_shares: Vec<Vec<Fr>> = y_pub
+        .chunks(pp.l)
+        .map(|s| pp.pack(s.to_vec(), rng))
+        .collect();
+    let y_shares = transpose(y_shares);
+
+    let msm_masks = MsmMask::sample(&pp, rng);
+
     network
-        .simulate_network_round((), |net, _| async move {
-            let pp = PackedSharingParams::<Fr>::new(2);
-            let dom = Radix2EvaluationDomain::<Fr>::new(1 << 8).unwrap();
-            d_msm_test::<ark_bls12_377::G1Projective, _>(&pp, &dom, &net).await;
+        .simulate_network_round((x_pub, y_pub, x_shares, y_shares, msm_masks, pp), |net, (x_pub, y_pub, x_shares, y_shares, msm_masks, pp)| async move {
+            let idx = net.party_id() as usize;
+            d_msm_test::<ark_bls12_377::G1Projective, _>(&x_pub, &y_pub, &x_shares[idx], &y_shares[idx], &msm_masks[idx], &pp, &net).await;
         })
         .await;
 }

--- a/dist-primitives/src/dfft/mod.rs
+++ b/dist-primitives/src/dfft/mod.rs
@@ -60,7 +60,8 @@ impl<F: FftField + PrimeField> FftMask<F> {
             for i in 0..mask_values.len() / pp.l {
                 out_shares.push(
                     pp.pack(
-                        mask_values.iter()
+                        mask_values
+                            .iter()
                             .skip(i)
                             .step_by(mask_values.len() / pp.l)
                             .cloned()
@@ -241,7 +242,11 @@ async fn fft2_with_rearrange<F: FftField + PrimeField, Net: MpcSerNet>(
     let rng = &mut ark_std::test_rng();
     let mbyl = px.len();
 
-    let out = px.iter().zip(fft_mask.in_mask.iter()).map(|(x, m)| *x + *m).collect::<Vec<_>>();
+    let out = px
+        .iter()
+        .zip(fft_mask.in_mask.iter())
+        .map(|(x, m)| *x + *m)
+        .collect::<Vec<_>>();
 
     let received_shares = net
         .client_send_or_king_receive_serialized(&out, sid, pp.t)
@@ -296,7 +301,11 @@ async fn fft2_with_rearrange<F: FftField + PrimeField, Net: MpcSerNet>(
         .await?;
 
     // unmask
-    let out_share = out_share.iter().zip(fft_mask.out_mask.iter()).map(|(x, m)| *x + *m).collect::<Vec<_>>();
+    let out_share = out_share
+        .iter()
+        .zip(fft_mask.out_mask.iter())
+        .map(|(x, m)| *x + *m)
+        .collect::<Vec<_>>();
 
     Ok(out_share)
 }

--- a/dist-primitives/src/dfft/mod.rs
+++ b/dist-primitives/src/dfft/mod.rs
@@ -83,6 +83,15 @@ impl<F: FftField + PrimeField> FftMask<F> {
             })
             .collect()
     }
+
+    /// Returns a default value for FftMask. Not secure.
+    /// Only to be used for debugging purposes.
+    pub fn zero(mbyl: usize) -> Self {
+        Self {
+            in_mask: vec![F::zero(); mbyl],
+            out_mask: vec![F::zero(); mbyl],
+        }
+    }
 }
 
 /// Takes as input packed shares of evaluations a polynomial over dom and outputs shares of the FFT of the polynomial

--- a/dist-primitives/src/dfft/tests.rs
+++ b/dist-primitives/src/dfft/tests.rs
@@ -241,7 +241,7 @@ mod tests {
             pack_evals.push(pp.pack(secrets, rng));
         }
 
-        let fft_mask = [
+        let fft_masks = [
             FftMask::<F>::sample(
                 true,
                 constraint_coset.coset_offset(),
@@ -280,11 +280,11 @@ mod tests {
         let result =
             network
                 .simulate_network_round(
-                    (pack_evals, fft_mask, pp, constraint, constraint_coset),
+                    (pack_evals, fft_masks, pp, constraint, constraint_coset),
                     |net,
                      (
                         pack_evals,
-                        fft_mask,
+                        fft_masks,
                         pp,
                         constraint,
                         constraint_coset,
@@ -297,7 +297,7 @@ mod tests {
                         // starting with evals over dom
                         let p_coeff = d_ifft(
                             peval_share,
-                            &fft_mask[0][idx],
+                            &fft_masks[0][idx],
                             true,
                             &constraint,
                             constraint_coset.coset_offset(),
@@ -309,7 +309,7 @@ mod tests {
                         .unwrap();
                         let coset_peval_share = d_fft(
                             p_coeff,
-                            &fft_mask[1][idx],
+                            &fft_masks[1][idx],
                             true,
                             &constraint,
                             &pp,
@@ -321,7 +321,7 @@ mod tests {
                         // obtained evals over coset_dom
                         let p_coeff = d_ifft(
                             coset_peval_share,
-                            &fft_mask[2][idx],
+                            &fft_masks[2][idx],
                             true,
                             &constraint,
                             constraint_coset.coset_offset_inv(),
@@ -333,7 +333,7 @@ mod tests {
                         .unwrap();
                         d_fft(
                             p_coeff,
-                            &fft_mask[3][idx],
+                            &fft_masks[3][idx],
                             false,
                             &constraint,
                             &pp,

--- a/dist-primitives/src/dfft/tests.rs
+++ b/dist-primitives/src/dfft/tests.rs
@@ -1,0 +1,349 @@
+mod tests {
+    use ark_bls12_377::Fr as F;
+    use ark_ff::FftField;
+    use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
+    use ark_std::{One, UniformRand};
+    use mpc_net::LocalTestNet;
+    use mpc_net::MpcNet;
+    use mpc_net::MultiplexedStreamID;
+    use secret_sharing::pss::PackedSharingParams;
+
+    use crate::dfft::FftMask;
+    use crate::dfft::d_fft;
+    use crate::dfft::d_ifft;
+    use crate::dfft::fft_in_place_rearrange;
+    use crate::utils::pack::transpose;
+
+    const L: usize = 2;
+    const M: usize = L * 4;
+
+    #[tokio::test]
+    async fn d_ifft_works() {
+        let rng = &mut ark_std::test_rng();
+        let pp = PackedSharingParams::<F>::new(L);
+        let constraint = Radix2EvaluationDomain::<F>::new(M).unwrap();
+        let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
+        let mut poly_evals = (0..M).map(|_| F::rand(rng)).collect::<Vec<_>>();
+        let poly_coeffs = constraint.ifft(&poly_evals);
+
+        fft_in_place_rearrange(&mut poly_evals);
+        let mut pack_evals: Vec<Vec<F>> = Vec::new();
+        for i in 0..M / pp.l {
+            let secrets = poly_evals
+                .iter()
+                .skip(i)
+                .step_by(M / pp.l)
+                .cloned()
+                .collect::<Vec<_>>();
+            pack_evals.push(pp.pack(secrets, rng));
+        }
+
+        let ifft_mask = FftMask::<F>::sample(
+            false,
+            F::one(),
+            constraint.group_gen_inv(),
+            M,
+            &pp,
+            rng,
+        );
+
+        let result = network
+            .simulate_network_round(
+                (pack_evals, ifft_mask, pp, constraint),
+                |net, (pack_evals, ifft_mask, pp, constraint)| async move {
+                    let idx = net.party_id() as usize;
+                    let pack_eval =
+                        pack_evals.iter().map(|x| x[idx]).collect::<Vec<_>>();
+                    d_ifft(
+                        pack_eval,
+                        &ifft_mask[idx],
+                        false,
+                        &constraint,
+                        F::one(),
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::Zero,
+                    )
+                    .await
+                    .unwrap()
+                },
+            )
+            .await;
+
+        let computed_poly_coeffs = transpose(result)
+            .into_iter()
+            .flat_map(|x| pp.unpack(x))
+            .collect::<Vec<_>>();
+
+        assert_eq!(poly_coeffs, computed_poly_coeffs);
+    }
+
+    #[tokio::test]
+    async fn d_fft_works() {
+        let rng = &mut ark_std::test_rng();
+        let pp = PackedSharingParams::<F>::new(L);
+        let constraint = Radix2EvaluationDomain::<F>::new(M).unwrap();
+        let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
+        let mut poly_coeffs = (0..M).map(|_| F::rand(rng)).collect::<Vec<_>>();
+        let poly_evals = constraint.fft(&poly_coeffs);
+
+        fft_in_place_rearrange(&mut poly_coeffs);
+
+        let mut pack_coeffs: Vec<Vec<F>> = Vec::new();
+        for i in 0..M / pp.l {
+            let secrets = poly_coeffs
+                .iter()
+                .skip(i)
+                .step_by(M / pp.l)
+                .cloned()
+                .collect::<Vec<_>>();
+            pack_coeffs.push(pp.pack(secrets, rng));
+        }
+
+        let fft_mask = FftMask::<F>::sample(
+            false,
+            F::one(),
+            constraint.group_gen(),
+            M,
+            &pp,
+            rng,
+        );
+
+        let result = network
+            .simulate_network_round(
+                (pack_coeffs, fft_mask, pp, constraint),
+                |net, (pack_coeffs, fft_mask, pp, constraint)| async move {
+                    let idx = net.party_id() as usize;
+                    let pack_coeff =
+                        pack_coeffs.iter().map(|x| x[idx]).collect::<Vec<_>>();
+                    d_fft(
+                        pack_coeff,
+                        &fft_mask[idx],
+                        false,
+                        &constraint,
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::Zero,
+                    )
+                    .await
+                    .unwrap()
+                },
+            )
+            .await;
+
+        let computed_poly_evals = transpose(result)
+            .into_iter()
+            .flat_map(|x| pp.unpack(x))
+            .collect::<Vec<_>>();
+
+        assert_eq!(poly_evals, computed_poly_evals);
+    }
+
+    #[tokio::test]
+    async fn d_ifftxd_fft_works() {
+        let rng = &mut ark_std::test_rng();
+        let pp = PackedSharingParams::<F>::new(L);
+        let constraint = Radix2EvaluationDomain::<F>::new(M).unwrap();
+        let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
+        let mut poly_evals = (0..M).map(|_| F::rand(rng)).collect::<Vec<_>>();
+        let expected_evals = poly_evals.clone();
+
+        fft_in_place_rearrange(&mut poly_evals);
+        let mut pack_evals: Vec<Vec<F>> = Vec::new();
+        for i in 0..M / pp.l {
+            let secrets = poly_evals
+                .iter()
+                .skip(i)
+                .step_by(M / pp.l)
+                .cloned()
+                .collect::<Vec<_>>();
+            pack_evals.push(pp.pack(secrets, rng));
+        }
+
+        let ifft_mask = FftMask::<F>::sample(
+            true,
+            F::one(),
+            constraint.group_gen_inv(),
+            M,
+            &pp,
+            rng,
+        );
+
+        let fft_mask = FftMask::<F>::sample(
+            false,
+            F::one(),
+            constraint.group_gen(),
+            M,
+            &pp,
+            rng,
+        );
+
+
+        let result = network
+            .simulate_network_round(
+                (pack_evals, ifft_mask, fft_mask, pp, constraint),
+                |net, (pack_evals, ifft_mask, fft_mask, pp, constraint)| async move {
+                    let idx = net.party_id() as usize;
+                    let pack_eval =
+                        pack_evals.iter().map(|x| x[idx]).collect::<Vec<_>>();
+                    let p_coeff = d_ifft(
+                        pack_eval,
+                        &ifft_mask[idx],
+                        true,
+                        &constraint,
+                        F::one(),
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::Zero,
+                    )
+                    .await
+                    .unwrap();
+                    d_fft(
+                        p_coeff,
+                        &fft_mask[idx],
+                        false,
+                        &constraint,
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::Zero,
+                    )
+                    .await
+                    .unwrap()
+                },
+            )
+            .await;
+        let computed_poly_evals = transpose(result)
+            .into_iter()
+            .flat_map(|x| pp.unpack(x))
+            .collect::<Vec<_>>();
+
+        assert_eq!(expected_evals, computed_poly_evals);
+    }
+
+    #[tokio::test]
+    async fn coset_d_ifftxd_fft_works() {
+        let rng = &mut ark_std::test_rng();
+        let pp = PackedSharingParams::<F>::new(L);
+        let constraint = Radix2EvaluationDomain::<F>::new(M).unwrap();
+        let constraint_coset = constraint.get_coset(F::GENERATOR).unwrap();
+        let network = LocalTestNet::new_local_testnet(pp.n).await.unwrap();
+        let mut poly_evals = (0..M).map(|_| F::rand(rng)).collect::<Vec<_>>();
+        let expected_poly_evals = poly_evals.clone();
+
+        fft_in_place_rearrange(&mut poly_evals);
+        let mut pack_evals: Vec<Vec<F>> = Vec::new();
+        for i in 0..M / pp.l {
+            let secrets = poly_evals
+                .iter()
+                .skip(i)
+                .step_by(M / pp.l)
+                .cloned()
+                .collect::<Vec<_>>();
+            pack_evals.push(pp.pack(secrets, rng));
+        }
+
+        let fft_mask = [
+            FftMask::<F>::sample(
+                true,
+                constraint_coset.coset_offset(),
+                constraint.group_gen_inv(),
+                M,
+                &pp,
+                rng,
+            ),
+            FftMask::<F>::sample(
+                true,
+                F::one(),
+                constraint_coset.group_gen(),
+                M,
+                &pp,
+                rng,
+            ),
+            FftMask::<F>::sample(
+                true,
+                constraint_coset.coset_offset_inv(),
+                constraint.group_gen_inv(),
+                M,
+                &pp,
+                rng,
+            ),
+            FftMask::<F>::sample(
+                false,
+                F::one(),
+                constraint_coset.group_gen(),
+                M,
+                &pp,
+                rng,
+            ),
+        ];
+
+        eprintln!("Running coset_d_ifftxd_ifft ...");
+        let result = network
+            .simulate_network_round(
+                (pack_evals, fft_mask, pp, constraint, constraint_coset),
+                |net, (pack_evals, fft_mask, pp, constraint, constraint_coset)| async move {
+                    let idx = net.party_id() as usize;
+                    let peval_share =
+                        pack_evals.iter().map(|x| x[idx]).collect::<Vec<_>>();
+                    // starting with evals over dom
+                    let p_coeff = d_ifft(
+                        peval_share,
+                        &fft_mask[0][idx],
+                        true,
+                        &constraint,
+                        constraint_coset.coset_offset(),
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::Zero,
+                    )
+                    .await
+                    .unwrap();
+                    let coset_peval_share = d_fft(
+                        p_coeff,
+                        &fft_mask[1][idx],
+                        true,
+                        &constraint,
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::Zero,
+                    )
+                    .await
+                    .unwrap();
+                    // obtained evals over coset_dom
+                    let p_coeff = d_ifft(
+                        coset_peval_share,
+                        &fft_mask[2][idx],
+                        true,
+                        &constraint,
+                        constraint_coset.coset_offset_inv(),
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::Zero,
+                    )
+                    .await
+                    .unwrap();
+                    d_fft(
+                        p_coeff,
+                        &fft_mask[3][idx],
+                        false,
+                        &constraint,
+                        &pp,
+                        &net,
+                        MultiplexedStreamID::Zero,
+                    )
+                    .await
+                    .unwrap()
+                    // back to evals over dom
+                },
+            )
+            .await;
+        eprintln!("coset_d_ifftxd_fft done ...");
+        eprintln!("Computing x evals from the shares ...");
+        let computed_poly_evals = transpose(result)
+            .into_iter()
+            .flat_map(|x| pp.unpack(x))
+            .collect::<Vec<_>>();
+
+        assert_eq!(expected_poly_evals, computed_poly_evals);
+    }
+}

--- a/dist-primitives/src/dmsm/mod.rs
+++ b/dist-primitives/src/dmsm/mod.rs
@@ -1,13 +1,54 @@
 use ark_ec::CurveGroup;
+use ark_ff::UniformRand;
 use mpc_net::ser_net::MpcSerNet;
 use mpc_net::{MpcNetError, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
 
+/// Masks used in dmsm
+/// Note that this only contains one share of the mask
+#[derive(Clone)]
+pub struct MsmMask<G: CurveGroup> {
+    pub in_mask: G,
+    pub out_mask: G,
+}
+
+impl<G: CurveGroup> MsmMask<G> {
+    pub fn new(in_mask: G, out_mask: G) -> Self {
+        Self { in_mask, out_mask }
+    }
+
+    /// Samples a random MsmMask and returns the shares of n parties
+    pub fn sample(
+        pp: &PackedSharingParams<G::ScalarField>,
+        rng: &mut impl rand::Rng,
+    ) -> Vec<Self> {
+        let gen = G::generator();
+        let mut mask_values = Vec::new();
+        for _ in 0..pp.l {
+            mask_values.push(G::ScalarField::rand(rng));
+        }
+
+        let mask_values: Vec<G> = mask_values.iter().map(|x| gen * x).collect();
+        let out_mask_value = -(mask_values.iter().sum::<G>());
+
+        let in_mask_shares = pp.pack(mask_values, rng);
+
+        // TODO: use regular secret sharing here. Currently using packed secret sharing with repeated secrets.
+        // doesn't affect correctness/privacy but would give a little bit of performance
+        let out_mask_shares = pp.pack(vec![out_mask_value; pp.l], rng);
+
+        in_mask_shares
+            .into_iter()
+            .zip(out_mask_shares.iter())
+            .map(|(in_mask_share, out_mask_share)| Self::new(in_mask_share, out_mask_share.clone()))
+            .collect()
+    }
+}
+
 pub async fn d_msm<G: CurveGroup, Net: MpcSerNet>(
     bases: &[G::Affine],
     scalars: &[G::ScalarField],
-    in_mask: G,
-    out_mask: G,
+    msm_mask: &MsmMask<G>,
     pp: &PackedSharingParams<G::ScalarField>,
     net: &Net,
     sid: MultiplexedStreamID,
@@ -19,7 +60,7 @@ pub async fn d_msm<G: CurveGroup, Net: MpcSerNet>(
     debug_assert_eq!(bases.len(), scalars.len());
     log::debug!("bases: {}, scalars: {}", bases.len(), scalars.len());
     let c_share = G::msm(bases, scalars)?;
-    let c_share = c_share + in_mask;
+    let c_share = c_share + msm_mask.in_mask;
     // Now we do degree reduction -- psstoss
     // Send to king who reduces and sends shamir shares (not packed).
     // Should be randomized. First convert to projective share.
@@ -39,8 +80,11 @@ pub async fn d_msm<G: CurveGroup, Net: MpcSerNet>(
         .client_receive_or_king_send_serialized(king_answer, sid)
         .await;
 
+    // At the end all parties hold a packed secret sharing of the output
+    // Note that the output is just a single group element and it is shared
+    // using "repeated" packed secret sharing i.e equivalent to pp.pack(vec![output; pp.l])
     if let Ok(output) = result {
-        Ok(output + out_mask)
+        Ok(output + msm_mask.out_mask)
     } else {
         result
     }

--- a/dist-primitives/src/dmsm/mod.rs
+++ b/dist-primitives/src/dmsm/mod.rs
@@ -40,7 +40,9 @@ impl<G: CurveGroup> MsmMask<G> {
         in_mask_shares
             .into_iter()
             .zip(out_mask_shares.iter())
-            .map(|(in_mask_share, out_mask_share)| Self::new(in_mask_share, out_mask_share.clone()))
+            .map(|(in_mask_share, out_mask_share)| {
+                Self::new(in_mask_share, out_mask_share.clone())
+            })
             .collect()
     }
 }

--- a/dist-primitives/src/dmsm/mod.rs
+++ b/dist-primitives/src/dmsm/mod.rs
@@ -45,6 +45,15 @@ impl<G: CurveGroup> MsmMask<G> {
             })
             .collect()
     }
+
+    /// Returns a default value for MsmMask. Not secure.
+    /// Only to be used for debugging purposes.
+    pub fn zero() -> Self {
+        Self {
+            in_mask: G::zero(),
+            out_mask: G::zero(),
+        }
+    }
 }
 
 pub async fn d_msm<G: CurveGroup, Net: MpcSerNet>(

--- a/dist-primitives/src/dmsm/mod.rs
+++ b/dist-primitives/src/dmsm/mod.rs
@@ -41,7 +41,7 @@ impl<G: CurveGroup> MsmMask<G> {
             .into_iter()
             .zip(out_mask_shares.iter())
             .map(|(in_mask_share, out_mask_share)| {
-                Self::new(in_mask_share, out_mask_share.clone())
+                Self::new(in_mask_share, *out_mask_share)
             })
             .collect()
     }

--- a/dist-primitives/src/dpp/mod.rs
+++ b/dist-primitives/src/dpp/mod.rs
@@ -2,7 +2,7 @@
 // Given x1, x2, .., xn, output x1, x1*x2, x1*x2*x3, .., x1*x2*..*xn
 
 use crate::utils::{
-    deg_red::deg_red,
+    deg_red::{deg_red, DegRedMask},
     pack::{pack_vec, transpose},
 };
 use ark_ff::{FftField, Field, PrimeField};
@@ -15,10 +15,12 @@ use secret_sharing::pss::PackedSharingParams;
 pub async fn d_pp<F: FftField + PrimeField + Field, Net: MpcSerNet>(
     num: Vec<F>,
     den: Vec<F>,
+    degred_mask: &DegRedMask<F, F>,
     pp: &PackedSharingParams<F>,
     net: &Net,
     sid: MultiplexedStreamID,
 ) -> Result<Vec<F>, MpcNetError> {
+    // TODO: replace with good randomness
     // using some dummy randomness
     let s = F::from(1_u32);
     let sinv = s.inverse().unwrap();
@@ -80,7 +82,6 @@ pub async fn d_pp<F: FftField + PrimeField + Field, Net: MpcSerNet>(
     // Finally, remove the ranomness in the partial products
     // multiply all entries of pp_pxss by of s
     // do degree reduction
-    // todo: replace in_mask and out_mask
     pp_numden_rand.iter_mut().for_each(|x| *x *= sinv);
-    deg_red(pp_numden_rand, vec![F::zero(); pp.l], vec![F::zero(); pp.l], pp, net, sid).await //packed shares of partial products
+    deg_red(pp_numden_rand, degred_mask, pp, net, sid).await //packed shares of partial products
 }

--- a/dist-primitives/src/dpp/mod.rs
+++ b/dist-primitives/src/dpp/mod.rs
@@ -80,6 +80,7 @@ pub async fn d_pp<F: FftField + PrimeField + Field, Net: MpcSerNet>(
     // Finally, remove the ranomness in the partial products
     // multiply all entries of pp_pxss by of s
     // do degree reduction
+    // todo: replace in_mask and out_mask
     pp_numden_rand.iter_mut().for_each(|x| *x *= sinv);
-    deg_red(pp_numden_rand, pp, net, sid).await //packed shares of partial products
+    deg_red(pp_numden_rand, vec![F::zero(); pp.l], vec![F::zero(); pp.l], pp, net, sid).await //packed shares of partial products
 }

--- a/dist-primitives/src/utils/deg_red.rs
+++ b/dist-primitives/src/utils/deg_red.rs
@@ -64,6 +64,16 @@ where
             })
             .collect()
     }
+
+    /// Returns a default value for DegRedMask. Not secure.
+    /// Only to be used for debugging purposes.
+    pub fn zero(num: usize) -> Self {
+        Self {
+            in_mask: vec![T::zero(); num],
+            out_mask: vec![T::zero(); num],
+            _marker: std::marker::PhantomData,
+        }
+    }
 }
 
 /// Reduces the degree of a poylnomial with the help of king

--- a/dist-primitives/src/utils/deg_red.rs
+++ b/dist-primitives/src/utils/deg_red.rs
@@ -59,7 +59,9 @@ where
         in_mask_shares
             .into_iter()
             .zip(out_mask_shares.iter())
-            .map(|(in_mask, out_mask)| Self::new(in_mask, out_mask.clone()))
+            .map(|(in_mask_share, out_mask_share)| {
+                Self::new(in_mask_share, out_mask_share.clone())
+            })
             .collect()
     }
 }

--- a/dist-primitives/src/utils/pack.rs
+++ b/dist-primitives/src/utils/pack.rs
@@ -4,6 +4,7 @@ use ark_std::{cfg_chunks, UniformRand};
 use rand::thread_rng;
 use secret_sharing::pss::PackedSharingParams;
 
+// TODO: maybe make this an impl of pp?
 pub fn pack_vec<F: FftField, T: DomainCoeff<F> + UniformRand>(
     secrets: &Vec<T>,
     pp: &PackedSharingParams<F>,

--- a/dist-primitives/src/utils/pack.rs
+++ b/dist-primitives/src/utils/pack.rs
@@ -1,12 +1,13 @@
 use ark_ff::FftField;
-use ark_std::cfg_chunks;
+use ark_poly::domain::DomainCoeff;
+use ark_std::{cfg_chunks, UniformRand};
 use rand::thread_rng;
 use secret_sharing::pss::PackedSharingParams;
 
-pub fn pack_vec<F: FftField>(
-    secrets: &Vec<F>,
+pub fn pack_vec<F: FftField, T: DomainCoeff<F> + UniformRand>(
+    secrets: &Vec<T>,
     pp: &PackedSharingParams<F>,
-) -> Vec<Vec<F>> {
+) -> Vec<Vec<T>> {
     debug_assert_eq!(secrets.len() % pp.l, 0, "Mismatch of size in pack_vec");
 
     let rng = &mut thread_rng();

--- a/groth16/examples/sha256.rs
+++ b/groth16/examples/sha256.rs
@@ -1,22 +1,25 @@
-use std::sync::Arc;
-
-use ark_bn254::{Bn254, Fr as Bn254Fr};
+use ark_bn254::{Bn254, Fr as Bn254Fr, G1Projective as G1, G2Projective as G2};
 use ark_circom::{CircomBuilder, CircomConfig, CircomReduction};
 use ark_crypto_primitives::snark::SNARK;
 use ark_ec::pairing::Pairing;
 use ark_ec::CurveGroup;
 use ark_ff::BigInt;
 use ark_groth16::{Groth16, Proof};
+use ark_poly::EvaluationDomain;
 use ark_poly::Radix2EvaluationDomain;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
-use ark_std::{cfg_chunks, cfg_into_iter, end_timer, start_timer, Zero};
+use ark_std::{cfg_chunks, cfg_into_iter, end_timer, start_timer, One, Zero};
+use std::sync::Arc;
 
+use dist_primitives::dfft::FftMask;
+use dist_primitives::dmsm::MsmMask;
+use dist_primitives::utils::deg_red::DegRedMask;
 use groth16::qap::qap;
 use groth16::{ext_wit, qap};
 use log::debug;
 use mpc_net::{LocalTestNet as Net, MpcNet, MultiplexedStreamID};
 
-use rand::SeedableRng;
+use rand::{thread_rng, SeedableRng};
 use secret_sharing::pss::PackedSharingParams;
 
 use groth16::proving_key::PackedProvingKeyShare;
@@ -33,58 +36,78 @@ async fn dsha256<E, Net>(
     >,
     a_share: &[E::ScalarField],
     ax_share: &[E::ScalarField],
+    r_share: E::ScalarField,
+    s_share: E::ScalarField,
+    fft_mask: &[FftMask<E::ScalarField>; 6],
+    f_degred_mask: &DegRedMask<E::ScalarField, E::ScalarField>,
+    g1_msm_mask: &[MsmMask<E::G1>; 4],
+    g2_msm_mask: &MsmMask<E::G2>,
     net: &Net,
 ) -> (E::G1, E::G2, E::G1)
 where
     E: Pairing,
     Net: MpcNet,
 {
-    let h_share = ext_wit::circom_h(qap_share, pp, &net).await.unwrap();
+    // TODO: Find a better way to send the masks as they currently use borrows and end up needing clones.
+    let h_share =
+        ext_wit::circom_h(qap_share, fft_mask, f_degred_mask, pp, &net)
+            .await
+            .unwrap();
     let msm_section = start_timer!(|| "MSM operations");
     // Compute msm while dropping the base vectors as they are not used again
     let compute_a = start_timer!(|| "Compute A");
+    // TODO: Use appropriate values of L, N
     let pi_a_share = groth16::prove::A::<E> {
         L: Default::default(),
         N: Default::default(),
-        r: E::ScalarField::zero(),
+        r: r_share,
         pp,
         S: &crs_share.s,
         a: a_share,
     }
-    .compute(net, MultiplexedStreamID::Zero)
+    .compute(&g1_msm_mask[0], net, MultiplexedStreamID::Zero)
     .await
     .unwrap();
     end_timer!(compute_a);
 
+    // TODO: Use appropriate values of Z, K
     let compute_b = start_timer!(|| "Compute B");
     let pi_b_share: E::G2 = groth16::prove::B::<E> {
         Z: Default::default(),
         K: Default::default(),
-        s: E::ScalarField::zero(),
+        s: s_share,
         pp,
         V: &crs_share.v,
         a: a_share,
     }
-    .compute(net, MultiplexedStreamID::Zero)
+    .compute(&g2_msm_mask, net, MultiplexedStreamID::Zero)
     .await
     .unwrap();
     end_timer!(compute_b);
 
+    // TODO: Use appropriate values for M
     let compute_c = start_timer!(|| "Compute C");
     let pi_c_share = groth16::prove::C::<E> {
         W: &crs_share.w,
         U: &crs_share.u,
         A: pi_a_share,
         M: Default::default(),
-        r: E::ScalarField::zero(),
-        s: E::ScalarField::zero(),
+        r: r_share,
+        s: s_share,
         pp,
         H: &crs_share.h,
         a: a_share,
         ax: ax_share,
         h: &h_share,
     }
-    .compute(net)
+    .compute(
+        &[
+            g1_msm_mask[1].clone(),
+            g1_msm_mask[2].clone(),
+            g1_msm_mask[3].clone(),
+        ],
+        net,
+    )
     .await
     .unwrap();
     end_timer!(compute_c);
@@ -153,6 +176,7 @@ async fn main() {
         qap::<Bn254Fr, Radix2EvaluationDomain<_>>(&matrices, &full_assignment)
             .unwrap();
 
+    // TODO: use random values for r and s and update shares accordingly
     let r = Bn254Fr::zero();
     let s = Bn254Fr::zero();
     let arkworks_proof = Groth16::<Bn254, CircomReduction>::create_proof_with_reduction_and_matrices(
@@ -165,9 +189,11 @@ async fn main() {
         &full_assignment,
     ).unwrap();
 
+    // Change number of parties here l = n/4
     let pp = PackedSharingParams::new(2);
+    let r_shares = vec![Bn254Fr::zero(); pp.n];
+    let s_shares = vec![Bn254Fr::zero(); pp.n];
     let qap_shares = qap.pss(&pp);
-    let pp = PackedSharingParams::new(pp.l);
     let crs_shares =
         PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(&pk, pp);
     let crs_shares = Arc::new(crs_shares);
@@ -178,21 +204,194 @@ async fn main() {
         pack_from_witness::<Bn254>(&pp, full_assignment[1..].to_vec());
     let network = Net::new_local_testnet(pp.n).await.unwrap();
 
-    let result = network
+    // compute masks
+    let domain = qap_shares[0].domain;
+    let rng = &mut thread_rng();
+
+    let root_of_unity = {
+        let domain_size_double = 2 * domain.size();
+        let domain_double =
+            Radix2EvaluationDomain::<Bn254Fr>::new(domain_size_double).unwrap();
+        domain_double.element(1)
+    };
+
+    let fft_masks = [
+        FftMask::<Bn254Fr>::sample(
+            true,
+            root_of_unity,
+            domain.group_gen_inv(),
+            domain.size(),
+            &pp,
+            rng,
+        ),
+        FftMask::<Bn254Fr>::sample(
+            true,
+            root_of_unity,
+            domain.group_gen_inv(),
+            domain.size(),
+            &pp,
+            rng,
+        ),
+        FftMask::<Bn254Fr>::sample(
+            true,
+            root_of_unity,
+            domain.group_gen_inv(),
+            domain.size(),
+            &pp,
+            rng,
+        ),
+        FftMask::<Bn254Fr>::sample(
+            false,
+            Bn254Fr::one(),
+            domain.group_gen(),
+            domain.size(),
+            &pp,
+            rng,
+        ),
+        FftMask::<Bn254Fr>::sample(
+            false,
+            Bn254Fr::one(),
+            domain.group_gen(),
+            domain.size(),
+            &pp,
+            rng,
+        ),
+        FftMask::<Bn254Fr>::sample(
+            false,
+            Bn254Fr::one(),
+            domain.group_gen(),
+            domain.size(),
+            &pp,
+            rng,
+        ),
+    ];
+
+    let f_degred_masks = DegRedMask::<Bn254Fr, Bn254Fr>::sample(
+        &pp,
+        Bn254Fr::from(1u32),
+        domain.size() / pp.l,
+        rng,
+    );
+
+    let g1_msm_mask: [Vec<MsmMask<G1>>; 4] = [
+        MsmMask::sample(&pp, rng),
+        MsmMask::sample(&pp, rng),
+        MsmMask::sample(&pp, rng),
+        MsmMask::sample(&pp, rng),
+    ];
+
+    let g2_msm_masks = MsmMask::<G2>::sample(&pp, rng);
+
+    let result: Vec<(G1, G2, G1)> = network
         .simulate_network_round(
-            (crs_shares, pp, a_shares, ax_shares, qap_shares),
-            |net, (crs_shares, pp, a_shares, ax_shares, qap_shares)| async move {
+            (
+                crs_shares,
+                pp,
+                a_shares,
+                ax_shares,
+                qap_shares,
+                r_shares,
+                s_shares,
+                fft_masks,
+                f_degred_masks,
+                g1_msm_mask,
+                g2_msm_masks,
+            ),
+            |net,
+             (
+                crs_shares,
+                pp,
+                a_shares,
+                ax_shares,
+                qap_shares,
+                r_shares,
+                s_shares,
+                fft_masks,
+                f_degred_masks,
+                g1_msm_mask,
+                g2_msm_masks,
+            )| async move {
                 let idx = net.party_id() as usize;
-                let crs_share =
-                    crs_shares.get(idx).unwrap();
+                let crs_share = crs_shares.get(idx).unwrap();
                 let a_share = &a_shares[idx];
                 let ax_share = &ax_shares[idx];
                 let qap_share = qap_shares[idx].clone();
-                dsha256(&pp, crs_share, qap_share, a_share, ax_share, &net).await
+                let r_share = r_shares[idx];
+                let s_share = s_shares[idx];
+                let f_degred_mask = &f_degred_masks[idx];
+                let g2_msm_mask = &g2_msm_masks[idx];
+                let fft_mask = [
+                    fft_masks[0][idx].clone(),
+                    fft_masks[1][idx].clone(),
+                    fft_masks[2][idx].clone(),
+                    fft_masks[3][idx].clone(),
+                    fft_masks[4][idx].clone(),
+                    fft_masks[5][idx].clone(),
+                ];
+
+                let g1_msm_mask = [
+                    g1_msm_mask[0][idx].clone(),
+                    g1_msm_mask[1][idx].clone(),
+                    g1_msm_mask[2][idx].clone(),
+                    g1_msm_mask[3][idx].clone(),
+                ];
+
+                ////////debugging with defaults
+                // let fft_mask = [
+                //     FftMask::default(qap_share.a.len()).clone(),
+                //     FftMask::default(qap_share.a.len()).clone(),
+                //     FftMask::default(qap_share.a.len()).clone(),
+                //     FftMask::default(qap_share.a.len()).clone(),
+                //     FftMask::default(qap_share.a.len()).clone(),
+                //     FftMask::default(qap_share.a.len()).clone(),
+                // ];
+
+                // let f_degred_mask = &DegRedMask::default(f_degred_mask.in_mask.len());
+
+                // fails
+                // let g1_msm_mask = [
+                //     MsmMask::default().clone(),
+                //     MsmMask::default().clone(),
+                //     MsmMask::default().clone(),
+                //     MsmMask::default().clone(),
+                // ];
+
+                // fails
+                // let g2_msm_mask = MsmMask::default().clone();
+                /////////////////////////////////
+
+                dsha256(
+                    &pp,
+                    crs_share,
+                    qap_share,
+                    a_share,
+                    ax_share,
+                    r_share,
+                    s_share,
+                    &fft_mask,
+                    f_degred_mask,
+                    &g1_msm_mask,
+                    &g2_msm_mask,
+                    &net,
+                )
+                .await
             },
         )
         .await;
-    let (mut a, mut b, c) = result[0];
+
+    let mut a_shares = Vec::new();
+    let mut b_shares = Vec::new();
+    let mut c_shares = Vec::new();
+    for (a_share, b_share, c_share) in result.into_iter() {
+        a_shares.push(a_share);
+        b_shares.push(b_share);
+        c_shares.push(c_share);
+    }
+
+    let mut a = pp.unpack2(a_shares)[0];
+    let mut b = pp.unpack2(b_shares)[0];
+    let c = pp.unpack2(c_shares)[0];
+
     // These elements are needed to construct the full proof, they are part of the proving key.
     // however, we can just send these values to the client, not the full proving key.
     a += pk.a_query[0] + vk.alpha_g1;

--- a/groth16/examples/sha256.rs
+++ b/groth16/examples/sha256.rs
@@ -56,7 +56,7 @@ where
     let msm_section = start_timer!(|| "MSM operations");
     // Compute msm while dropping the base vectors as they are not used again
     let compute_a = start_timer!(|| "Compute A");
-    // TODO: Use appropriate values of L, N
+    // TODO: Use appropriate values of L, N taken from the unpacked CRS
     let pi_a_share = groth16::prove::A::<E> {
         L: Default::default(),
         N: Default::default(),
@@ -70,7 +70,7 @@ where
     .unwrap();
     end_timer!(compute_a);
 
-    // TODO: Use appropriate values of Z, K
+    // TODO: Use appropriate values of Z, K taken from the unpacked CRS
     let compute_b = start_timer!(|| "Compute B");
     let pi_b_share: E::G2 = groth16::prove::B::<E> {
         Z: Default::default(),
@@ -85,7 +85,7 @@ where
     .unwrap();
     end_timer!(compute_b);
 
-    // TODO: Use appropriate values for M
+    // TODO: Use appropriate values for M taken from the unpacked CRS
     let compute_c = start_timer!(|| "Compute C");
     let pi_c_share = groth16::prove::C::<E> {
         W: &crs_share.w,

--- a/groth16/examples/sha256.rs
+++ b/groth16/examples/sha256.rs
@@ -200,10 +200,8 @@ async fn main() {
 
     // Change number of parties here l = n/4
     let pp = PackedSharingParams::new(2);
-    // TODO: Share the random values r and s
-    // currently we are just sending them as is.
-    let r_shares = vec![r; pp.n];
-    let s_shares = vec![s; pp.n];
+    let r_shares = pp.pack(vec![r; pp.n], rng);
+    let s_shares = pp.pack(vec![s; pp.n], rng);
     let qap_shares = qap.pss(&pp);
     let crs_shares =
         PackedProvingKeyShare::<Bn254>::pack_from_arkworks_proving_key(&pk, pp);

--- a/groth16/examples/sha256.rs
+++ b/groth16/examples/sha256.rs
@@ -336,30 +336,6 @@ async fn main() {
                     g1_msm_mask[3][idx].clone(),
                 ];
 
-                ////////debugging with defaults
-                // let fft_mask = [
-                //     FftMask::default(qap_share.a.len()).clone(),
-                //     FftMask::default(qap_share.a.len()).clone(),
-                //     FftMask::default(qap_share.a.len()).clone(),
-                //     FftMask::default(qap_share.a.len()).clone(),
-                //     FftMask::default(qap_share.a.len()).clone(),
-                //     FftMask::default(qap_share.a.len()).clone(),
-                // ];
-
-                // let f_degred_mask = &DegRedMask::default(f_degred_mask.in_mask.len());
-
-                // fails
-                // let g1_msm_mask = [
-                //     MsmMask::default().clone(),
-                //     MsmMask::default().clone(),
-                //     MsmMask::default().clone(),
-                //     MsmMask::default().clone(),
-                // ];
-
-                // fails
-                // let g2_msm_mask = MsmMask::default().clone();
-                /////////////////////////////////
-
                 dsha256(
                     &pp,
                     crs_share,

--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -3,7 +3,7 @@ use ark_poly::{domain::EvaluationDomain, Radix2EvaluationDomain};
 
 pub mod ext_wit;
 pub mod pre_processing;
-// pub mod prove;
+pub mod prove;
 pub mod proving_key;
 pub mod qap;
 

--- a/groth16/src/lib.rs
+++ b/groth16/src/lib.rs
@@ -3,7 +3,7 @@ use ark_poly::{domain::EvaluationDomain, Radix2EvaluationDomain};
 
 pub mod ext_wit;
 pub mod pre_processing;
-pub mod prove;
+// pub mod prove;
 pub mod proving_key;
 pub mod qap;
 

--- a/groth16/src/prove.rs
+++ b/groth16/src/prove.rs
@@ -39,6 +39,8 @@ impl<'a, E: Pairing> A<'a, E> {
         // Given packed shares of S_i and au_i terms, the servers can use πMSM (dmsm) to compute ∏{i∈[0,Q−1]}(S_i)^a_i.
         // Since the output of MSM are regular shares, they can then be combined with L, N and regular shares
         // of r to get regular shares of A.
+        // Note: for simplicity, we actually implement MSM such that the output shares are packed shares of the same 
+        // value repeated l times. Therefore they can be combined with L, N and packed shares of r to get packed shares of A.
 
         // Calculate (N)^r
         let v0 = self.N * self.r;
@@ -201,8 +203,6 @@ impl<'a, E: Pairing> C<'a, E> {
 
         const CHANNEL0: MultiplexedStreamID = MultiplexedStreamID::Zero;
         const CHANNEL1: MultiplexedStreamID = MultiplexedStreamID::One;
-
-        // TODO: replace in_mask and out_mask
 
         // Calculate ∏{i∈[l+1,m]}(W_i)^a_i using dmsm
         // NOTE: this `l_aux_acc`

--- a/groth16/src/prove.rs
+++ b/groth16/src/prove.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, clippy::too_many_arguments)]
 
 use ark_ec::pairing::Pairing;
+use ark_ff::Zero;
 use dist_primitives::dmsm::d_msm;
 use mpc_net::{MpcNet, MpcNetError, MultiplexedStreamID};
 use secret_sharing::pss::PackedSharingParams;
@@ -38,7 +39,16 @@ impl<'a, E: Pairing> A<'a, E> {
         let v1 = self.L + v0;
 
         // Calculate ∏{i∈[0,m]}(S_i)^a_i using dmsm
-        let prod = d_msm::<E::G1, _>(self.S, self.a, self.pp, net, sid).await?;
+        let prod = d_msm::<E::G1, _>(
+            self.S,
+            self.a,
+            E::G1::zero(),
+            E::G1::zero(),
+            self.pp,
+            net,
+            sid,
+        )
+        .await?;
 
         let A = v1 + prod;
 
@@ -77,7 +87,16 @@ impl<'a, E: Pairing> B<'a, E> {
         // Calculate Z.(K)^s
         let v1 = self.Z + v0;
         // Calculate ∏{i∈[0,m]}(V_i)^a_i using dmsm
-        let prod = d_msm::<E::G2, _>(self.V, self.a, self.pp, net, sid).await?;
+        let prod = d_msm::<E::G2, _>(
+            self.V,
+            self.a,
+            E::G2::zero(),
+            E::G2::zero(),
+            self.pp,
+            net,
+            sid,
+        )
+        .await?;
 
         let B = v1 + prod;
 
@@ -115,12 +134,38 @@ impl<'a, E: Pairing> C<'a, E> {
         const CHANNEL1: MultiplexedStreamID = MultiplexedStreamID::One;
         const CHANNEL2: MultiplexedStreamID = MultiplexedStreamID::Two;
 
+        // todo: replace in_mask and out_mask
+
         // Calculate ∏{i∈[l+1,m]}(W_i)^a_i using dmsm
-        let w = d_msm::<E::G1, _>(self.W, self.ax, self.pp, net, CHANNEL0);
+        let w = d_msm::<E::G1, _>(
+            self.W,
+            self.ax,
+            E::G1::zero(),
+            E::G1::zero(),
+            self.pp,
+            net,
+            CHANNEL0,
+        );
         // Calculate ∏{i∈[0,Q−2]}(U_i)^h_i using dmsm
-        let u = d_msm::<E::G1, _>(self.U, self.h, self.pp, net, CHANNEL1);
+        let u = d_msm::<E::G1, _>(
+            self.U,
+            self.h,
+            E::G1::zero(),
+            E::G1::zero(),
+            self.pp,
+            net,
+            CHANNEL1,
+        );
         // Calculate ∏{i∈[0,m]}(H_i)^a_i using dmsm
-        let h = d_msm::<E::G1, _>(self.H, self.a, self.pp, net, CHANNEL2);
+        let h = d_msm::<E::G1, _>(
+            self.H,
+            self.a,
+            E::G1::zero(),
+            E::G1::zero(),
+            self.pp,
+            net,
+            CHANNEL2,
+        );
 
         let (w, u, h) = tokio::try_join!(w, u, h)?;
 

--- a/groth16/src/prove.rs
+++ b/groth16/src/prove.rs
@@ -39,7 +39,7 @@ impl<'a, E: Pairing> A<'a, E> {
         // Given packed shares of S_i and au_i terms, the servers can use πMSM (dmsm) to compute ∏{i∈[0,Q−1]}(S_i)^a_i.
         // Since the output of MSM are regular shares, they can then be combined with L, N and regular shares
         // of r to get regular shares of A.
-        // Note: for simplicity, we actually implement MSM such that the output shares are packed shares of the same 
+        // Note: for simplicity, we actually implement MSM such that the output shares are packed shares of the same
         // value repeated l times. Therefore they can be combined with L, N and packed shares of r to get packed shares of A.
 
         // Calculate (N)^r

--- a/groth16/src/proving_key.rs
+++ b/groth16/src/proving_key.rs
@@ -16,11 +16,24 @@ use rayon::prelude::*;
     Clone, Debug, Default, PartialEq, CanonicalSerialize, CanonicalDeserialize,
 )]
 pub struct PackedProvingKeyShare<E: Pairing> {
+    /// s = `a_query[1..]`
     pub s: Vec<E::G1Affine>,
+    /// u = `h_query`
     pub u: Vec<E::G1Affine>,
-    pub v: Vec<E::G2Affine>,
+    /// w = `l_query`
     pub w: Vec<E::G1Affine>,
+    /// h = `b_g1_query[1..]`
     pub h: Vec<E::G1Affine>,
+    /// v = `b_g2_query[1..]`
+    pub v: Vec<E::G2Affine>,
+    pub a_query0: E::G1Affine,
+    pub b_g1_query0: E::G1Affine,
+    pub b_g2_query0: E::G2Affine,
+    pub delta_g1: E::G1Affine,
+    pub delta_g2: E::G2Affine,
+    pub alpha_g1: E::G1Affine,
+    pub beta_g1: E::G1Affine,
+    pub beta_g2: E::G2Affine,
 }
 
 impl<E: Pairing> PackedProvingKeyShare<E>
@@ -56,21 +69,20 @@ where
             .map(Into::into)
             .collect::<Vec<_>>();
 
-        let rng = &mut ark_std::test_rng();
         let packed_s = cfg_chunks!(pre_packed_s, pp.l)
-            .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
+            .map(|chunk| pp.det_pack::<E::G1>(chunk.to_vec()))
             .collect::<Vec<_>>();
         let packed_u = cfg_chunks!(pre_packed_u, pp.l)
-            .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
+            .map(|chunk| pp.det_pack::<E::G1>(chunk.to_vec()))
             .collect::<Vec<_>>();
         let packed_w = cfg_chunks!(pre_packed_w, pp.l)
-            .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
+            .map(|chunk| pp.det_pack::<E::G1>(chunk.to_vec()))
             .collect::<Vec<_>>();
         let packed_h = cfg_chunks!(pre_packed_h, pp.l)
-            .map(|chunk| pp.pack::<E::G1>(chunk.to_vec(), rng))
+            .map(|chunk| pp.det_pack::<E::G1>(chunk.to_vec()))
             .collect::<Vec<_>>();
         let packed_v = cfg_chunks!(pre_packed_v, pp.l)
-            .map(|chunk| pp.pack::<E::G2>(chunk.to_vec(), rng))
+            .map(|chunk| pp.det_pack::<E::G2>(chunk.to_vec()))
             .collect::<Vec<_>>();
 
         cfg_into_iter!(0..pp.n)
@@ -97,6 +109,14 @@ where
                     v: v_shares,
                     w: w_shares,
                     h: h_shares,
+                    a_query0: pk.a_query[0],
+                    b_g1_query0: pk.b_g1_query[0],
+                    b_g2_query0: pk.b_g2_query[0],
+                    delta_g1: pk.delta_g1,
+                    delta_g2: pk.vk.delta_g2,
+                    alpha_g1: pk.vk.alpha_g1,
+                    beta_g1: pk.beta_g1,
+                    beta_g2: pk.vk.beta_g2,
                 }
             })
             .collect()
@@ -144,6 +164,14 @@ where
             v: v_shares,
             w: w_shares,
             h: h_shares,
+            a_query0: E::G1Affine::rand(rng),
+            b_g1_query0: E::G1Affine::rand(rng),
+            b_g2_query0: E::G2Affine::rand(rng),
+            delta_g1: E::G1Affine::rand(rng),
+            delta_g2: E::G2Affine::rand(rng),
+            alpha_g1: E::G1Affine::rand(rng),
+            beta_g1: E::G1Affine::rand(rng),
+            beta_g2: E::G2Affine::rand(rng),
         }
     }
 }

--- a/secret-sharing/src/pss.rs
+++ b/secret-sharing/src/pss.rs
@@ -75,7 +75,7 @@ impl<F: FftField> PackedSharingParams<F> {
         let mut result = secrets;
 
         // Resize the secrets with t zeros
-        result.append(&mut vec![T::zero(); self.t]);
+        result.resize(self.t, T::zero());
 
         // interpolating on secrets domain
         self.secret.ifft_in_place(&mut result);


### PR DESCRIPTION
The high level organization is as follows:
1. Each distributed primitive has an associated struct which stores the randomness.
2. These structs come with `sample` implementation, which can be run by the client to generate masks with the correct distribution. Effectively, it emulates a trusted dealer.
3. The various distributed primitives now additionally take these masks as input.

Before this PR can be merged there's a few things to complete in the SHA 256 example:

- [x] `r` and `s` need to be sampled randomly and used in the proof generation for zk
- [x] Various group elements in the CRS -- `L, M, N, K, Z` --  are not being loaded in correctly from the crs generated by arkworks. They are currently "default" values. These need to be updated.

To finish the above two tasks, it will be easiest to follow (https://github.com/arkworks-rs/groth16/blob/42b38f1675fd45aa4429a2d335653e37507ec95c/src/prover.rs#L54) and ensure each component is computed correctly. Perhaps we should also setup up a simple example for easy development -- a repeated multiplication circuit with 1024 (say) constraints.

Note: masks for dpp has not been implemented as it is not used in groth16. This is a low priority task.